### PR TITLE
Treewalker

### DIFF
--- a/lib/treewalk/walk.go
+++ b/lib/treewalk/walk.go
@@ -8,10 +8,6 @@ type Node interface {
 	NextChild() Node
 }
 
-func Walk(root Node, preVisit WalkFunc, postVisit WalkFunc) error {
-	return walk(root, preVisit, postVisit)
-}
-
 type WalkFunc func(node Node) error
 
 /*
@@ -21,7 +17,7 @@ type WalkFunc func(node Node) error
 var SkipNode = errors.New("skip this node")
 
 /*
-	walk recursively descends tree,
+	Walk recursively descends a tree,
 	calling `preVisit` on each node,
 	then walking children,
 	then calling `postVisit` on the node.
@@ -30,7 +26,7 @@ var SkipNode = errors.New("skip this node")
 	The post-visition function may similarly drop references to children
 	(and probably should, to reduce memory use on large trees).
 */
-func walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
+func Walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
 	err := preVisit(node)
 	if err != nil {
 		if err == SkipNode {
@@ -40,7 +36,7 @@ func walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
 	}
 
 	for next := node.NextChild(); next != nil; next = node.NextChild() {
-		if err := walk(next, preVisit, postVisit); err != nil {
+		if err := Walk(next, preVisit, postVisit); err != nil {
 			return err
 		}
 	}

--- a/lib/treewalk/walk.go
+++ b/lib/treewalk/walk.go
@@ -1,0 +1,50 @@
+package treewalk
+
+import (
+	"errors"
+)
+
+type Node interface {
+	NextChild() Node
+}
+
+func Walk(root Node, preVisit WalkFunc, postVisit WalkFunc) error {
+	return walk(root, preVisit, postVisit)
+}
+
+type WalkFunc func(node Node) error
+
+/*
+	SkipNode is used as a return value from WalkFuncs to indicate that the node named in the call (and all its children) are to be skipped.
+	It only makes sense to return this from the pre-visit function; it's by definition too late after the post-visit function.
+*/
+var SkipNode = errors.New("skip this node")
+
+/*
+	walk recursively descends tree, calling walkFn.
+*/
+func walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
+	err := preVisit(node)
+	if err != nil {
+		if err == SkipNode {
+			return nil
+		}
+		return err
+	}
+
+	for next := node.NextChild(); next != nil; next = node.NextChild() {
+		if err := walk(next, preVisit, postVisit); err != nil {
+			return err
+		}
+	}
+
+	err = postVisit(node)
+	if err != nil {
+		if err == SkipNode {
+			return nil
+		}
+		return err
+	}
+
+	return nil
+}

--- a/lib/treewalk/walk.go
+++ b/lib/treewalk/walk.go
@@ -21,7 +21,14 @@ type WalkFunc func(node Node) error
 var SkipNode = errors.New("skip this node")
 
 /*
-	walk recursively descends tree, calling walkFn.
+	walk recursively descends tree,
+	calling `preVisit` on each node,
+	then walking children,
+	then calling `postVisit` on the node.
+
+	The pre-visit function may add children.
+	The post-visition function may similarly drop references to children
+	(and probably should, to reduce memory use on large trees).
 */
 func walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
 	err := preVisit(node)

--- a/lib/treewalk/walk_test.go
+++ b/lib/treewalk/walk_test.go
@@ -1,0 +1,46 @@
+package treewalk
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type testNode struct {
+	value string
+
+	children []*testNode
+	itrIndex int // next child offset
+}
+
+func (t *testNode) NextChild() Node {
+	if t.itrIndex >= len(t.children) {
+		return nil
+	}
+	t.itrIndex++
+	return t.children[t.itrIndex-1]
+}
+
+func Test(t *testing.T) {
+	Convey("Given a single node", t, func() {
+		root := &testNode{}
+
+		Convey("We can walk and each visitor is called once", func() {
+			previsitCount := 0
+			postvisitCount := 0
+
+			preVisit := func(Node) error {
+				previsitCount++
+				return nil
+			}
+			postVisit := func(Node) error {
+				postvisitCount++
+				return nil
+			}
+
+			So(Walk(root, preVisit, postVisit), ShouldBeNil)
+			So(previsitCount, ShouldEqual, 1)
+			So(postvisitCount, ShouldEqual, 1)
+		})
+	})
+}

--- a/lib/treewalk/walk_test.go
+++ b/lib/treewalk/walk_test.go
@@ -1,6 +1,7 @@
 package treewalk
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -41,6 +42,116 @@ func Test(t *testing.T) {
 			So(Walk(root, preVisit, postVisit), ShouldBeNil)
 			So(previsitCount, ShouldEqual, 1)
 			So(postvisitCount, ShouldEqual, 1)
+		})
+	})
+
+	Convey("Given a depth=2 tree", t, func() {
+		root := &testNode{
+			children: []*testNode{
+				{},
+				{},
+				{},
+			},
+		}
+
+		Convey("We can walk and each visitor is called once per node", func() {
+			previsitCount := 0
+			postvisitCount := 0
+
+			preVisit := func(Node) error {
+				previsitCount++
+				return nil
+			}
+			postVisit := func(Node) error {
+				postvisitCount++
+				return nil
+			}
+
+			So(Walk(root, preVisit, postVisit), ShouldBeNil)
+			So(previsitCount, ShouldEqual, 4)
+			So(postvisitCount, ShouldEqual, 4)
+		})
+	})
+
+	Convey("Given a deep and ragged tree", t, func() {
+		root := &testNode{
+			value: "1",
+			children: []*testNode{
+				{
+					value: "1.1",
+					children: []*testNode{
+						{value: "1.1.1"},
+						{value: "1.1.2"},
+						{value: "1.1.3"},
+					}},
+				{
+					value: "1.2",
+				},
+				{
+					value: "1.3",
+					children: []*testNode{
+						{
+							value: "1.3.1",
+							children: []*testNode{
+								{value: "1.3.1.1"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Convey("We can walk and each visitor is called once per node", func() {
+			previsitCount := 0
+			postvisitCount := 0
+
+			preVisit := func(Node) error {
+				previsitCount++
+				return nil
+			}
+			postVisit := func(Node) error {
+				postvisitCount++
+				return nil
+			}
+
+			So(Walk(root, preVisit, postVisit), ShouldBeNil)
+			So(previsitCount, ShouldEqual, 9)
+			So(postvisitCount, ShouldEqual, 9)
+		})
+
+		Convey("Visitation occurs in order", func() {
+			var record []string
+
+			preVisit := func(n Node) error {
+				record = append(record, "previsit  "+n.(*testNode).value)
+				return nil
+			}
+			postVisit := func(n Node) error {
+				record = append(record, "postvisit "+n.(*testNode).value)
+				return nil
+			}
+
+			So(Walk(root, preVisit, postVisit), ShouldBeNil)
+			So(strings.Join(record, "\n"), ShouldEqual, strings.Join([]string{
+				"previsit  1",
+				"previsit  1.1",
+				"previsit  1.1.1",
+				"postvisit 1.1.1",
+				"previsit  1.1.2",
+				"postvisit 1.1.2",
+				"previsit  1.1.3",
+				"postvisit 1.1.3",
+				"postvisit 1.1",
+				"previsit  1.2",
+				"postvisit 1.2",
+				"previsit  1.3",
+				"previsit  1.3.1",
+				"previsit  1.3.1.1",
+				"postvisit 1.3.1.1",
+				"postvisit 1.3.1",
+				"postvisit 1.3",
+				"postvisit 1",
+			}, "\n"))
 		})
 	})
 }


### PR DESCRIPTION
A simple iterator interface that, when implemented, lets you conveniently do a visitor pattern walk on a tree.  Critically, with both pre-order and post-order visitation... which means after this is merged, I can replace `filepath.Walk` and fix the remaining skipped tests in the `dir` input implementation that need post-order visitation to build.  Right after that, also will be useful for walking trees in the hash buckets and building the final hash.

Consumer code tends to end up with a type assertion as the first step in every `WalkFunc`.  I can't think of any way to make this suck less... of course Generics would, but... golang.

(More general than repeatr?  Absolutely.  Resisting the temptation to put it in a grabbag "golang-utils" library until we actually discover an impetus to do so.)