### PR TITLE
Unify jobdirs

### DIFF
--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -51,7 +51,7 @@ func (x *Executor) run(formula def.Formula) (def.Job, []def.Output) {
 
 	var job def.Job
 
-	flak.WithTempDir(func(jobPath string) {
+	flak.WithDir(func(jobPath string) {
 		rootfsPath := filepath.Join(jobPath, "rootfs")
 		if err := os.MkdirAll(rootfsPath, 0755); err != nil {
 			panic(Error.Wrap(errors.IOError.Wrap(err))) // REVIEW: WorkspaceIOError?  or a flag that indicates "wow, super hosed"?

--- a/executor/dispatch/dispatch.go
+++ b/executor/dispatch/dispatch.go
@@ -1,8 +1,12 @@
 package executordispatch
 
 import (
+	"os"
+	"path/filepath"
+
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/executor/chroot"
 	"polydawn.net/repeatr/executor/nsinit"
 	"polydawn.net/repeatr/executor/null"
 )
@@ -19,9 +23,14 @@ func Get(desire string) *executor.Executor {
 		executor = &null.Executor{}
 	case "nsinit":
 		executor = &nsinit.Executor{}
+	case "chroot":
+		executor = &chroot.Executor{}
 	default:
 		panic(def.ValidationError.New("No such executor %s", desire))
 	}
+
+	// Set the base path to operate from
+	executor.Configure(filepath.Join(os.TempDir(), "repeatr", "executor", desire))
 
 	return &executor
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -5,5 +5,13 @@ import (
 )
 
 type Executor interface {
+	Configure(workspacePath string)
+
+	/*
+
+		The executor expects to be configured with a workspace path, and will create a directory inside that, probably with a job GUID.
+		It is assumed that any job-specific filesystem state will be cleaned up by the executor.
+
+	*/
 	Run(def.Formula) (def.Job, []def.Output)
 }

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -128,7 +128,7 @@ func (e *Executor) Run(job def.Formula) (def.Job, []def.Output) {
 	// make up a job id
 	jobID := def.JobID(guid.New())
 
-	flak.WithTempDir(func(d string) {
+	flak.WithDir(func(d string) {
 		resultJob, outputs = e.Execute(job, d)
 
 	}, e.workspacePath, "job", string(jobID))

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -12,6 +12,7 @@ import (
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/input/dispatch"
 	"polydawn.net/repeatr/lib/flak"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/output/dispatch"
 )
 
@@ -19,11 +20,16 @@ import (
 var _ executor.Executor = &Executor{}
 
 type Executor struct {
+	workspacePath string
+}
+
+func (e *Executor) Configure(workspacePath string) {
+	e.workspacePath = workspacePath
 }
 
 // Execute a forumla in a specified directory.
 // Directory is assumed to exist.
-func (*Executor) Execute(job def.Formula, d string) (def.Job, []def.Output) {
+func (e *Executor) Execute(job def.Formula, d string) (def.Job, []def.Output) {
 
 	// Dedicated rootfs folder to distinguish container from nsinit noise
 	rootfs := filepath.Join(d, "rootfs")
@@ -119,9 +125,13 @@ func (e *Executor) Run(job def.Formula) (def.Job, []def.Output) {
 	var resultJob def.Job
 	var outputs []def.Output
 
+	// make up a job id
+	jobID := def.JobID(guid.New())
+
 	flak.WithTempDir(func(d string) {
 		resultJob, outputs = e.Execute(job, d)
-	}, "nsinit")
+
+	}, e.workspacePath, "job", string(jobID))
 
 	Println("Done!")
 	return resultJob, outputs

--- a/executor/null/nil_executor.go
+++ b/executor/null/nil_executor.go
@@ -7,6 +7,9 @@ import (
 type Executor struct {
 }
 
+func (*Executor) Configure(workspacePath string) {
+}
+
 func (*Executor) Run(job def.Formula) (def.Job, []def.Output) {
 	return nil, nil
 }

--- a/input/input.go
+++ b/input/input.go
@@ -26,6 +26,8 @@ type Input interface {
 		The Input implementation is responsible for ensuring that the content
 		of this filesystem matches the hash described by the `def.Input` used
 		to construct the Input implementation.
+
+		The input expects the parent folder of its path to exist, but not the path itself.
 	*/
 	Apply(path string) <-chan error
 }

--- a/lib/flak/assist.go
+++ b/lib/flak/assist.go
@@ -42,7 +42,7 @@ func GetTempDir(dirs ...string) string {
 }
 
 // Runs a function with a tempdir, cleaning up afterward.
-func WithTempDir(f func(string), dirs ...string) {
+func WithDir(f func(string), dirs ...string) {
 
 	if len(dirs) < 1 {
 		panic(errors.ProgrammerError.New("Must have at least one sub-folder for tempdir"))


### PR DESCRIPTION
* Adds a `Configure(workspacePath string)` method to executor interface
* Added some quick documentation to a few files explaining expectations
* Unify executor's usage of temp job directory logic