### PR TITLE
Better cli test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,40 @@ Run it. Run it again.
 Repeatr is a process reasoning framework. You have things to do, and repeatr helps you do them!
 
 Repeatr is very much a work in progress. Some assembly may be required. Not tested on animals.
+
+## Try it out
+
+First, clone our repository and its dependencies, then download some testing assets:
+
+```bash
+# Clone
+git clone https://github.com/polydawn/repeatr.git && cd repeatr
+
+# Install dependencies
+./goad init
+
+# Download a small Ubuntu tarball and required binary
+./lib/integration/assets.sh
+```
+
+Build repeatr:
+
+```bash
+# Build
+./goad install
+
+# Try it out!
+sudo .gopath/bin/repeatr run -i lib/integration/basic.json
+
+# See the forumla repeatr has run
+cat lib/integration/basic.json
+
+# See the /var/log output repeatr has generated!
+tar -tf basic.tar
+```
+
+You can run our test suite (several of which will will be skipped without root):
+
+```
+sudo ./goad test
+```

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -16,13 +17,20 @@ var (
 
 func Test(t *testing.T) {
 
+	// Run from the top-level directory to avoid "../" irritants.
+	// Optional TODO: upgrade repeatr to understand how to be relative to a directory.
+	err := os.Chdir("..")
+	if err != nil {
+		panic(err)
+	}
+
 	Convey("It should not crash without args", t, func() {
 		App.Run(baseArgs)
 	})
 
 	testutil.Convey_IfCanNS("Within an environment that can run namespaces", t, func() {
 		testutil.Convey_IfHaveRoot("It should run a basic example", func() {
-			App.Run(append(baseArgs, "run", "-i", "../lib/integration/basic.json"))
+			App.Run(append(baseArgs, "run", "-i", "lib/integration/basic.json"))
 		})
 	})
 

--- a/goad
+++ b/goad
@@ -107,7 +107,7 @@ else
 		}
 		;;
 	clean)
-		rm -r $GOPATH/bin $GOPATH/pkg
+		rm -rf $GOPATH/bin $GOPATH/pkg
 		;;
 	run)
 		shift

--- a/lib/integration/basic.json
+++ b/lib/integration/basic.json
@@ -3,7 +3,7 @@
 		{
 			"Type": "tar",
 			"Location": "/",
-			"URI": "../assets/ubuntu.tar.gz"
+			"URI": "assets/ubuntu.tar.gz"
 		}
 	],
 	"Accents": {
@@ -13,7 +13,7 @@
 		{
 			"Type": "tar",
 			"Location": "/var/log",
-			"URI": "../basic.tar"
+			"URI": "basic.tar"
 		}
 	]
 }


### PR DESCRIPTION
* Fix CLI tests to run from the 'correct' directory, to get rid of dumb `../` prefixes
* Because of this, the basic integration test can double as a human-friendly demo
* Added some demonstration instructions!