### PR TITLE
Check all outputs from test executions

### DIFF
--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -61,7 +61,7 @@ func Test(t *testing.T) {
 			}
 			So(os.Mkdir(executor.workspacePath, 0755), ShouldBeNil)
 
-			Convey("The executor should be able to invoke echo", func() {
+			Convey("The executor should be able to invoke echo", FailureContinues, func() {
 				formula.Accents = def.Accents{
 					Entrypoint: []string{"echo", "echococo"},
 				}
@@ -96,7 +96,7 @@ func Test(t *testing.T) {
 				inputfixtures.DirInput2.Location = "/data/test"
 				formula.Inputs = append(formula.Inputs, inputfixtures.DirInput2)
 
-				Convey("The executor should be able to see the mounted files", func() {
+				Convey("The executor should be able to see the mounted files", FailureContinues, func() {
 					formula.Accents = def.Accents{
 						Entrypoint: []string{"ls", "/data/test"},
 					}


### PR DESCRIPTION
Goconvey's default behavior is to abort as soon as one assertion fails.  Adding the `FailureContinues` parameter to a block means any failure still fails the overall block, but will continue to do other checks in the block.  Here, this is useful to see differences in stdout/err even if, e.g., the exit code was nonzero (which is in fact when those strings are the most useful!).