### PR TITLE
Fix nsinit pathing to actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ Build repeatr:
 # Build
 ./goad install
 
-# Try it out!
-sudo .gopath/bin/repeatr run -i lib/integration/basic.json
+# See usage
+sudo ./goad exec
 
-# See the forumla repeatr has run
+# Try an example!
+sudo ./goad exec run -i lib/integration/basic.json
+
+# See the forumla repeatr just ran
 cat lib/integration/basic.json
 
 # See the /var/log output repeatr has generated!

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -100,7 +100,10 @@ func (e *Executor) Execute(job def.Formula, d string) (def.Job, []def.Output) {
 	}
 
 	Println("Running formula...")
-	cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		panic(err)
+	}
 
 	// Run outputs
 	for x, output := range job.Outputs {

--- a/goad
+++ b/goad
@@ -109,9 +109,9 @@ else
 	clean)
 		rm -rf $GOPATH/bin $GOPATH/pkg
 		;;
-	run)
+	exec)
 		shift
-		$GOPATH/bin/$name "$@"
+		PATH=$PWD/assets:$PATH $GOPATH/bin/$name "$@"
 		;;
 	*)
 		echo "Usage: $0 {init|test|install|fmt|doc|cover|validate|clean}" 1>&2;

--- a/lib/integration/basic.json
+++ b/lib/integration/basic.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"Accents": {
-		"Entrypoint": [ "whoami" ]
+		"Entrypoint": [ "echo", "Hello from repeatr!" ]
 	},
 	"Outputs": [
 		{


### PR DESCRIPTION
Turns out.... I had an `nsinit` binary on my system PATH the whole time. Functional reproducible environments, we have them.

This sets up `./goad exec` to run repeatr with a modified PATH until we fix nsinit binaries being a prerequisite. It also actually... checks the error when trying to run nsinit, so we know if it fails. Derp.