### PR TITLE
More io

### DIFF
--- a/def/somewhen.go
+++ b/def/somewhen.go
@@ -4,5 +4,5 @@ import (
 	"time"
 )
 
-var Somewhen time.Time = time.Date(2000, time.January, 15, 0, 0, 0, 0, time.UTC)
-var SomewhenNano int64 = Somewhen.UnixNano()
+var Epochwhen time.Time = time.Unix(0, 0).UTC()
+var EpochwhenNano int64 = 0

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -30,7 +30,7 @@ func (e *Executor) Configure(workspacePath string) {
 func (x *Executor) Run(formula def.Formula) (job def.Job, outs []def.Output) {
 	try.Do(func() {
 		job, outs = x.run(formula)
-	}).Catch(input.InputError, func(e *errors.Error) {
+	}).Catch(input.Error, func(e *errors.Error) {
 		// REVIEW: also directly pass input/output system errors up?  or, since we may have to gather several, put them in a group and wrap them in a "prereqs failed" executor error?
 		panic(e)
 	}).Catch(Error, func(e *errors.Error) {

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -37,7 +37,7 @@ func Test(t *testing.T) {
 			So(os.Mkdir(executor.workspacePath, 0755), ShouldBeNil)
 
 			Convey("We should get an InputError", func() {
-				So(func() { executor.Run(formula) }, testutil.ShouldPanicWith, input.InputError)
+				So(func() { executor.Run(formula) }, testutil.ShouldPanicWith, input.Error)
 			})
 		}),
 	)

--- a/input/dir/dir_input_test.go
+++ b/input/dir/dir_input_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/input"
-	"polydawn.net/repeatr/lib/fshash"
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/fspatch"
 	"polydawn.net/repeatr/testutil"
 )
@@ -57,11 +57,11 @@ func Test(t *testing.T) {
 			// remarkably, since the first read doesn't cause atimes to change,
 			// the inputter can capture it and we can recreate it.
 			// but that still doesn't make anything else about checking or handling it sane.
-			path0metadata := fshash.ReadMetadata("src")
+			path0metadata := fs.ReadMetadata("src")
 			path0metadata.Name = ""
-			path1metadata := fshash.ReadMetadata("src/a")
-			path2metadata := fshash.ReadMetadata("src/b")
-			path3metadata := fshash.ReadMetadata("src/b/c")
+			path1metadata := fs.ReadMetadata("src/a")
+			path2metadata := fs.ReadMetadata("src/b")
+			path3metadata := fs.ReadMetadata("src/b/c")
 
 			Convey("We can construct an input", func() {
 				inputter := New(def.Input{
@@ -87,11 +87,11 @@ func Test(t *testing.T) {
 							//one, _ := os.Lstat("src/a")
 							//two, _ := os.Lstat("dest/a")
 							//So(one, ShouldResemble, two)
-							So(fshash.ReadMetadata("dest/a"), ShouldResemble, path1metadata)
-							So(fshash.ReadMetadata("dest/b"), ShouldResemble, path2metadata)
-							So(fshash.ReadMetadata("dest/b/c"), ShouldResemble, path3metadata)
+							So(fs.ReadMetadata("dest/a"), ShouldResemble, path1metadata)
+							So(fs.ReadMetadata("dest/b"), ShouldResemble, path2metadata)
+							So(fs.ReadMetadata("dest/b/c"), ShouldResemble, path3metadata)
 							// the top dir should have the same attribs too!  but we have to fix the name.
-							destDirMeta := fshash.ReadMetadata("dest/")
+							destDirMeta := fs.ReadMetadata("dest/")
 							destDirMeta.Name = ""
 							So(destDirMeta, ShouldResemble, path0metadata)
 						})
@@ -192,16 +192,16 @@ func Test(t *testing.T) {
 						So(string(content), ShouldEqual, "zyx")
 
 						Convey("And all metadata matches", func() {
-							So(fshash.ReadMetadata("dest/a"), ShouldResemble, fshash.ReadMetadata("src/a"))
-							So(fshash.ReadMetadata("dest/b"), ShouldResemble, fshash.ReadMetadata("src/b"))
-							So(fshash.ReadMetadata("dest/b/c"), ShouldResemble, fshash.ReadMetadata("src/b/c"))
-							So(fshash.ReadMetadata("dest/b/d"), ShouldResemble, fshash.ReadMetadata("src/b/d"))
-							So(fshash.ReadMetadata("dest/b/d/link-rel"), ShouldResemble, fshash.ReadMetadata("src/b/d/link-rel"))
-							So(fshash.ReadMetadata("dest/link-abs"), ShouldResemble, fshash.ReadMetadata("src/link-abs"))
+							So(fs.ReadMetadata("dest/a"), ShouldResemble, fs.ReadMetadata("src/a"))
+							So(fs.ReadMetadata("dest/b"), ShouldResemble, fs.ReadMetadata("src/b"))
+							So(fs.ReadMetadata("dest/b/c"), ShouldResemble, fs.ReadMetadata("src/b/c"))
+							So(fs.ReadMetadata("dest/b/d"), ShouldResemble, fs.ReadMetadata("src/b/d"))
+							So(fs.ReadMetadata("dest/b/d/link-rel"), ShouldResemble, fs.ReadMetadata("src/b/d/link-rel"))
+							So(fs.ReadMetadata("dest/link-abs"), ShouldResemble, fs.ReadMetadata("src/link-abs"))
 							// the top dir should have the same attribs too!  but we have to fix the name.
-							srcDirMetadata := fshash.ReadMetadata("src/")
+							srcDirMetadata := fs.ReadMetadata("src/")
 							srcDirMetadata.Name = ""
-							destDirMeta := fshash.ReadMetadata("dest/")
+							destDirMeta := fs.ReadMetadata("dest/")
 							destDirMeta.Name = ""
 							So(destDirMeta, ShouldResemble, srcDirMetadata)
 						})

--- a/input/input.go
+++ b/input/input.go
@@ -32,6 +32,6 @@ type Input interface {
 	Apply(path string) <-chan error
 }
 
-var InputError *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
+var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
 
-var InputHashMismatchError *errors.ErrorClass = InputError.NewClass("InputHashMismatchError")
+var InputHashMismatchError *errors.ErrorClass = Error.NewClass("InputHashMismatchError")

--- a/input/tar/tar_input.go
+++ b/input/tar/tar_input.go
@@ -64,4 +64,4 @@ func (i Input) Apply(path string) <-chan error {
 	return done
 }
 
-var Error *errors.ErrorClass = input.InputError.NewClass("TarInputError") // currently contains little information because the returns of the subcommand are already opaque.  may become the root of a more expressive error hierarchy when we replace the tar implementation.
+var Error *errors.ErrorClass = input.Error.NewClass("TarInputError") // currently contains little information because the returns of the subcommand are already opaque.  may become the root of a more expressive error hierarchy when we replace the tar implementation.

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -111,6 +111,7 @@ func PlaceDirTime(destBasePath string, hdr Metadata) {
 
 func ScanFile(basePath, path string, optional ...os.FileInfo) (hdr Metadata, file io.ReadCloser) {
 	fullPath := filepath.Join(basePath, path)
+	// most of the heavy work is in ReadMetadata; this method just adds the file content
 	hdr = ReadMetadata(fullPath, optional...)
 	hdr.Name = path
 	switch hdr.Typeflag {

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -98,3 +98,13 @@ func PlaceFile(destBasePath string, hdr Metadata, body io.Reader) {
 		ioError(err)
 	}
 }
+
+// Exposed only because you're probably doing your own trees somehow, and it's
+// necessary to cover your tracks by forcing times on dirs after all children are done.
+// Symmetric params and error handling to `PlaceFile` for your convenience.
+func PlaceDirTime(destBasePath string, hdr Metadata) {
+	destPath := filepath.Join(destBasePath, hdr.Name)
+	if err := fspatch.LUtimesNano(destPath, hdr.AccessTime, hdr.ModTime); err != nil {
+		ioError(err)
+	}
+}

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -22,7 +22,7 @@ func PlaceFile(destBasePath string, hdr Metadata, body io.Reader) {
 
 	switch hdr.Typeflag {
 	case tar.TypeDir:
-		if hdr.Name == "./" {
+		if hdr.Name == "." {
 			// for the base dir only:
 			// the dir may exist; we'll just chown+chmod+chtime it.
 			// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -9,13 +9,10 @@ import (
 	"syscall"
 
 	"github.com/spacemonkeygo/errors"
-	"polydawn.net/repeatr/lib/fshash"
 	"polydawn.net/repeatr/lib/fspatch"
 )
 
-// TODO : move the fshash.Metadata type to this package
-
-func PlaceFile(destBasePath string, hdr fshash.Metadata, body io.Reader) {
+func PlaceFile(destBasePath string, hdr Metadata, body io.Reader) {
 	// 'destBasePath' should be an absolute path on the host.
 	// 'hdr.Name' should be the full relative path of the file.
 	// if it has an absolute prefix, that's quietly ignored, and it's treated as relative anyway.

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -108,3 +108,18 @@ func PlaceDirTime(destBasePath string, hdr Metadata) {
 		ioError(err)
 	}
 }
+
+func ScanFile(basePath, path string, optional ...os.FileInfo) (hdr Metadata, file io.ReadCloser) {
+	fullPath := filepath.Join(basePath, path)
+	hdr = ReadMetadata(fullPath, optional...)
+	hdr.Name = path
+	switch hdr.Typeflag {
+	case tar.TypeReg:
+		var err error
+		file, err = os.OpenFile(fullPath, os.O_RDONLY, 0)
+		if err != nil {
+			ioError(err)
+		}
+	}
+	return
+}

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -1,0 +1,103 @@
+package fs
+
+import (
+	"archive/tar"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/lib/fshash"
+	"polydawn.net/repeatr/lib/fspatch"
+)
+
+// TODO : move the fshash.Metadata type to this package
+
+func PlaceFile(destBasePath string, hdr fshash.Metadata, body io.Reader) {
+	// 'destBasePath' should be an absolute path on the host.
+	// 'hdr.Name' should be the full relative path of the file.
+	// if it has an absolute prefix, that's quietly ignored, and it's treated as relative anyway.
+
+	destPath := filepath.Join(destBasePath, hdr.Name)
+	mode := hdr.FileMode()
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if hdr.Name == "./" {
+			// for the base dir only:
+			// the dir may exist; we'll just chown+chmod+chtime it.
+			// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.
+			if fi, err := os.Lstat(destPath); err == nil && fi.IsDir() {
+				break
+			}
+		}
+		if err := os.Mkdir(destPath, mode); err != nil {
+			ioError(err)
+		}
+	case tar.TypeReg, tar.TypeRegA:
+		file, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY, mode)
+		if err != nil {
+			ioError(err)
+		}
+		if _, err := io.Copy(file, body); err != nil {
+			file.Close()
+			ioError(err)
+		}
+		file.Close()
+	case tar.TypeSymlink:
+		targetPath := filepath.Join(filepath.Dir(destPath), hdr.Linkname)
+		if !strings.HasPrefix(targetPath, destBasePath) {
+			panic(BreakoutError.New("invalid symlink %q -> %q", targetPath, hdr.Linkname))
+		}
+		if err := os.Symlink(hdr.Linkname, destPath); err != nil {
+			ioError(err)
+		}
+	case tar.TypeLink:
+		targetPath := filepath.Join(destBasePath, hdr.Linkname)
+		if !strings.HasPrefix(targetPath, destBasePath) {
+			panic(BreakoutError.New("invalid hardlink %q -> %q", targetPath, hdr.Linkname))
+		}
+		if err := os.Link(targetPath, destPath); err != nil {
+			ioError(err)
+		}
+	case tar.TypeBlock:
+		mode := uint32(hdr.Mode&07777) | syscall.S_IFBLK
+		if err := syscall.Mknod(destPath, mode, int(fspatch.Mkdev(hdr.Devmajor, hdr.Devminor))); err != nil {
+			ioError(err)
+		}
+	case tar.TypeChar:
+		mode := uint32(hdr.Mode&07777) | syscall.S_IFCHR
+		if err := syscall.Mknod(destPath, mode, int(fspatch.Mkdev(hdr.Devmajor, hdr.Devminor))); err != nil {
+			ioError(err)
+		}
+	case tar.TypeFifo:
+		if err := syscall.Mkfifo(destPath, uint32(hdr.Mode&07777)); err != nil {
+			ioError(err)
+		}
+	default:
+		panic(errors.NotImplementedError.New("The tennants of filesystems have changed!  We're not prepared for this file mode %q", hdr.Typeflag))
+	}
+
+	if err := os.Lchown(destPath, hdr.Uid, hdr.Gid); err != nil {
+		ioError(err)
+	}
+
+	for key, value := range hdr.Xattrs {
+		if err := fspatch.Lsetxattr(destPath, key, []byte(value), 0); err != nil {
+			ioError(err)
+		}
+	}
+
+	if hdr.Typeflag != tar.TypeSymlink {
+		// do this for everything not a symlink, since there's no such thing as `lchmod` on linux -.-
+		if err := os.Chmod(destPath, mode); err != nil {
+			ioError(err)
+		}
+	}
+
+	if err := fspatch.LUtimesNano(destPath, hdr.AccessTime, hdr.ModTime); err != nil {
+		ioError(err)
+	}
+}

--- a/lib/fs/errors.go
+++ b/lib/fs/errors.go
@@ -1,0 +1,19 @@
+package fs
+
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
+var Error *errors.ErrorClass = errors.NewClass("FSError") // grouping, do not instantiate
+
+/*
+	`BreakoutError` is raised when processing a filesystem description where links
+	(symlinks, hardlinks) are constructed in such a way that they would reach
+	out of the base directory.  Encountering these in a well-formed filesystem
+	description is basically an attempted attack.
+*/
+var BreakoutError *errors.ErrorClass = Error.NewClass("FSBreakoutError")
+
+func ioError(err error) {
+	panic(Error.Wrap(errors.IOError.Wrap(err)))
+}

--- a/lib/fs/metadata.go
+++ b/lib/fs/metadata.go
@@ -1,4 +1,4 @@
-package fshash
+package fs
 
 import (
 	"archive/tar"

--- a/lib/fs/metadata.go
+++ b/lib/fs/metadata.go
@@ -87,8 +87,9 @@ func ReadMetadata(path string, optional ...os.FileInfo) Metadata {
 	}
 	// ctimes are uncontrollable, pave them (╯°□°）╯︵ ┻━┻
 	// atimes mutate on read, pave them
-	hdr.ChangeTime = def.Somewhen
-	hdr.AccessTime = def.Somewhen
+	// we don't include these when hashing, but we wouldn't want uncontrolled bytes in a tar output either
+	hdr.ChangeTime = def.Epochwhen
+	hdr.AccessTime = def.Epochwhen
 	return Metadata(*hdr)
 }
 

--- a/lib/fs/metadata_test.go
+++ b/lib/fs/metadata_test.go
@@ -1,4 +1,4 @@
-package fshash
+package fs
 
 import (
 	"bytes"

--- a/lib/fs/walk.go
+++ b/lib/fs/walk.go
@@ -107,7 +107,6 @@ func (t *FilewalkNode) prepareChildren(basePath string) error {
 	memory as we walk.  `Walk()` wraps the user-defined post-visit function
 	to do this at the end.
 */
-func (t *FilewalkNode) forgetChildren() error {
+func (t *FilewalkNode) forgetChildren() {
 	t.children = nil
-	return nil
 }

--- a/lib/fs/walk.go
+++ b/lib/fs/walk.go
@@ -7,6 +7,8 @@ import (
 	"polydawn.net/repeatr/lib/treewalk"
 )
 
+type WalkFunc func(filenode *FilewalkNode) error
+
 /*
 	Walks a filesystem.
 
@@ -21,13 +23,13 @@ import (
 
 	Caveat: calling `node.NextChild()` during your walk results in undefined behavior.
 */
-func Walk(basePath string, preVisit treewalk.WalkFunc, postVisit treewalk.WalkFunc) error {
+func Walk(basePath string, preVisit WalkFunc, postVisit WalkFunc) error {
 	return treewalk.Walk(
 		newFileWalkNode(basePath, "."),
 		func(node treewalk.Node) error {
 			filenode := node.(*FilewalkNode)
 			if preVisit != nil {
-				if err := preVisit(node); err != nil {
+				if err := preVisit(filenode); err != nil {
 					return err
 				}
 			}
@@ -37,7 +39,7 @@ func Walk(basePath string, preVisit treewalk.WalkFunc, postVisit treewalk.WalkFu
 			filenode := node.(*FilewalkNode)
 			var err error
 			if postVisit != nil {
-				err = postVisit(node)
+				err = postVisit(filenode)
 			}
 			filenode.forgetChildren()
 			return err

--- a/lib/fs/walk.go
+++ b/lib/fs/walk.go
@@ -1,0 +1,108 @@
+package fs
+
+import (
+	"os"
+	"path/filepath"
+
+	"polydawn.net/repeatr/lib/treewalk"
+)
+
+/*
+	Walks a filesystem.
+
+	This is much like the standard library's `path/filepath.Walk`, except
+	it's based on `treewalk`, which means it supports both pre- and post-order
+	traversals.
+
+	Symlinks are not followed.
+
+	The traversal order of siblings is *not* guaranteed, and is *not* necessarily
+	stable.
+
+	Caveat: calling `node.NextChild()` during your walk results in undefined behavior.
+*/
+func Walk(basePath string, preVisit treewalk.WalkFunc, postVisit treewalk.WalkFunc) error {
+	return treewalk.Walk(
+		newFileWalkNode(basePath, "."),
+		func(node treewalk.Node) error {
+			filenode := node.(*FilewalkNode)
+			if preVisit != nil {
+				if err := preVisit(node); err != nil {
+					return err
+				}
+			}
+			return filenode.prepareChildren(basePath)
+		},
+		func(node treewalk.Node) error {
+			filenode := node.(*FilewalkNode)
+			var err error
+			if postVisit != nil {
+				err = postVisit(node)
+			}
+			filenode.forgetChildren()
+			return err
+		},
+	)
+}
+
+var _ treewalk.Node = &FilewalkNode{}
+
+type FilewalkNode struct {
+	Path string // relative to start
+	Info os.FileInfo
+	Err  error
+
+	children []*FilewalkNode // note we didn't sort this
+	itrIndex int             // next child offset
+}
+
+func (t *FilewalkNode) NextChild() treewalk.Node {
+	if t.itrIndex >= len(t.children) {
+		return nil
+	}
+	t.itrIndex++
+	return t.children[t.itrIndex-1]
+}
+
+func newFileWalkNode(basePath, path string) (filenode *FilewalkNode) {
+	filenode = &FilewalkNode{Path: path}
+	filenode.Info, filenode.Err = os.Lstat(filepath.Join(basePath, path))
+	// don't expand the children until the previsit function
+	// we don't want them all crashing into memory at once
+	return
+}
+
+/*
+	Expand next subtree.  Used in the pre-order visit step so we don't walk
+	every dir up front.  `Walk()` wraps the user-defined pre-visit function
+	to do this at the end.
+*/
+func (t *FilewalkNode) prepareChildren(basePath string) error {
+	if !t.Info.IsDir() {
+		return nil
+	}
+	f, err := os.Open(filepath.Join(basePath, t.Path))
+	if err != nil {
+		return err
+	}
+	names, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	t.children = make([]*FilewalkNode, len(names))
+	for i, name := range names {
+		t.children[i] = newFileWalkNode(basePath, "./"+filepath.Join(t.Path, name))
+	}
+	return nil
+}
+
+/*
+	Used in the post-order visit step so we don't continuously consume more
+	memory as we walk.  `Walk()` wraps the user-defined post-visit function
+	to do this at the end.
+*/
+func (t *FilewalkNode) forgetChildren() error {
+	t.children = nil
+	return nil
+}

--- a/lib/fs/walk.go
+++ b/lib/fs/walk.go
@@ -16,6 +16,9 @@ type WalkFunc func(filenode *FilewalkNode) error
 	it's based on `treewalk`, which means it supports both pre- and post-order
 	traversals.
 
+	All paths begin in `.`, e.g. you'll see a series like	`{".", "./a", "./a/b"}`, etc.
+	This is identical in behavior to `filepath.Clean` having been called on each path.
+
 	Symlinks are not followed.
 
 	The traversal order of siblings is *not* guaranteed, and is *not* necessarily

--- a/lib/fshash/bucket.go
+++ b/lib/fshash/bucket.go
@@ -2,6 +2,7 @@ package fshash
 
 import (
 	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/treewalk"
 )
 
@@ -14,16 +15,16 @@ import (
 	e.g. boltdb for really large file trees would also make sense.
 */
 type Bucket interface {
-	Record(metadata Metadata, contentHash []byte) // record a file into the bucket
-	Iterator() (rootRecord RecordIterator)        // return a treewalk root that does a traversal ordered by path
+	Record(metadata fs.Metadata, contentHash []byte) // record a file into the bucket
+	Iterator() (rootRecord RecordIterator)           // return a treewalk root that does a traversal ordered by path
 }
 
 type Record struct {
 	// Note: tags are to indicate that this field is serialized, but are a non-functional ornamentation.
 	// Serialization code is handcrafted in order to deal with order determinism and does not actually refer to them.
 
-	Metadata    Metadata `json:"m"`
-	ContentHash []byte   `json:"h"`
+	Metadata    fs.Metadata `json:"m"`
+	ContentHash []byte      `json:"h"`
 }
 
 /*

--- a/lib/fshash/bucket_memory.go
+++ b/lib/fshash/bucket_memory.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"strings"
 
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/treewalk"
 )
 
@@ -14,7 +15,7 @@ type MemoryBucket struct {
 	lines []Record
 }
 
-func (b *MemoryBucket) Record(metadata Metadata, contentHash []byte) {
+func (b *MemoryBucket) Record(metadata fs.Metadata, contentHash []byte) {
 	b.lines = append(b.lines, Record{metadata, contentHash})
 }
 

--- a/lib/fshash/fs_walk.go
+++ b/lib/fshash/fs_walk.go
@@ -160,6 +160,9 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 			// we could add a hash of inodes to bucket to address this.
 		}
 		return nil
+
+		// TODO : much of this function could now be ablated down to
+		// calling lib/fs.PlaceFile with the metadata that's just been read
 	}
 	postVisit := func(node treewalk.Node) error {
 		filenode := node.(*fileWalkNode)

--- a/lib/fshash/fs_walk.go
+++ b/lib/fshash/fs_walk.go
@@ -49,7 +49,7 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 			}
 			// marshal headers and save to bucket with hash
 			if destBasePath != "" {
-				if err := fspatch.UtimesNano(destPath, def.Somewhen, hdr.ModTime); err != nil {
+				if err := fspatch.UtimesNano(destPath, hdr.AccessTime, hdr.ModTime); err != nil {
 					return err
 				}
 				if err := os.Chown(destPath, hdr.Uid, hdr.Gid); err != nil {
@@ -63,7 +63,9 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 	}
 	postVisit := func(filenode *fs.FilewalkNode) error {
 		if filenode.Info.IsDir() && destBasePath != "" {
-			if err := fspatch.UtimesNano(filepath.Join(destBasePath, filenode.Path), def.Somewhen, filenode.Info.ModTime()); err != nil {
+			// XXX: this is looking back on the fileinfo instead of the header and punting on atime with a hack.
+			// this would be better if fs.FilewalkNode supported an attachment so we could stick the header on, but in practice, same values.
+			if err := fspatch.UtimesNano(filepath.Join(destBasePath, filenode.Path), def.Epochwhen, filenode.Info.ModTime()); err != nil {
 				return err
 			}
 		}

--- a/lib/fshash/fs_walk.go
+++ b/lib/fshash/fs_walk.go
@@ -10,15 +10,13 @@ import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/fspatch"
-	"polydawn.net/repeatr/lib/treewalk"
 )
 
 func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory func() hash.Hash) error {
 	// If copying: Dragons: you can set atime and you can set mtime, but you can't ever set ctime again.
 	// Filesystem APIs are constructed such that it's literally impossible to do an attribute-preserving copy in userland.
 
-	preVisit := func(node treewalk.Node) error {
-		filenode := node.(*fs.FilewalkNode)
+	preVisit := func(filenode *fs.FilewalkNode) error {
 		if filenode.Err != nil {
 			return filenode.Err
 		}
@@ -95,8 +93,7 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 		}
 		return nil
 	}
-	postVisit := func(node treewalk.Node) error {
-		filenode := node.(*fs.FilewalkNode)
+	postVisit := func(filenode *fs.FilewalkNode) error {
 		if filenode.Info.IsDir() && destBasePath != "" {
 			if err := fspatch.UtimesNano(filepath.Join(destBasePath, filenode.Path), def.Somewhen, filenode.Info.ModTime()); err != nil {
 				return err

--- a/lib/fshash/fs_walk.go
+++ b/lib/fshash/fs_walk.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spacemonkeygo/errors"
 	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/fspatch"
 	"polydawn.net/repeatr/lib/treewalk"
 )
@@ -75,7 +76,7 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 		mode := filenode.info.Mode()
 		switch {
 		case mode&os.ModeDir == os.ModeDir:
-			hdr := ReadMetadata(destPath, filenode.info)
+			hdr := fs.ReadMetadata(destPath, filenode.info)
 			hdr.Name = filenode.path
 			if destBasePath != "" {
 				if err := os.MkdirAll(destPath, mode&os.ModePerm); err != nil {
@@ -94,7 +95,7 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 			if link, err = os.Readlink(srcPath); err != nil {
 				return err
 			}
-			hdr := ReadMetadata(srcPath, filenode.info)
+			hdr := fs.ReadMetadata(srcPath, filenode.info)
 			hdr.Name = filenode.path
 			if destBasePath != "" {
 				if err := os.Symlink(link, destPath); err != nil {
@@ -140,7 +141,7 @@ func FillBucket(srcBasePath, destBasePath string, bucket Bucket, hasherFactory f
 				return err
 			}
 			// marshal headers and save to bucket with hash
-			hdr := ReadMetadata(destPath, filenode.info)
+			hdr := fs.ReadMetadata(destPath, filenode.info)
 			hdr.Name = filenode.path
 			if destBasePath != "" {
 				if err := fspatch.UtimesNano(destPath, def.Somewhen, hdr.ModTime); err != nil {

--- a/lib/fspatch/mkdev.go
+++ b/lib/fspatch/mkdev.go
@@ -1,0 +1,7 @@
+package fspatch
+
+// Workaround for https://github.com/golang/go/issues/8106 .
+// Remove freely after a fix for that lands upstream.
+func Mkdev(major int64, minor int64) uint32 {
+	return uint32(((minor & 0xfff00) << 12) | ((major & 0xfff) << 8) | (minor & 0xff))
+}

--- a/lib/fspatch/stat_unix.go
+++ b/lib/fspatch/stat_unix.go
@@ -1,0 +1,23 @@
+// +build linux
+// can probably be built on most of the platforms listed in tar/archive/stat_unix.go, but not sure so preferring to whitelist cautiously
+
+package fspatch
+
+import (
+	"os"
+	"syscall"
+)
+
+/*
+	Get the device numbers from a fileinfo.
+	Only makes sense on block and character devices.
+*/
+func ReadDev(fi os.FileInfo) (devmajor, devminor int64) {
+	sys, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	devmajor = int64((sys.Rdev >> 8) & 0xff)
+	devminor = int64((sys.Rdev & 0xff) | ((sys.Rdev >> 12) & 0xfff00))
+	return
+}

--- a/lib/fspatch/xattrs_linux.go
+++ b/lib/fspatch/xattrs_linux.go
@@ -1,0 +1,60 @@
+package fspatch
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Returns a nil slice and nil error if the xattr is not set
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, &os.PathError{"getxattr", path, err}
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, &os.PathError{"getxattr", path, err}
+	}
+
+	dest := make([]byte, 128)
+	destBytes := unsafe.Pointer(&dest[0])
+	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	if errno == syscall.ENODATA {
+		return nil, nil
+	}
+	if errno == syscall.ERANGE {
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	}
+	if errno != 0 {
+		return nil, &os.PathError{"getxattr", path, errno}
+	}
+
+	return dest[:sz], nil
+}
+
+var _zero uintptr
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return &os.PathError{"setxattr", path, err}
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return &os.PathError{"setxattr", path, err}
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return &os.PathError{"setxattr", path, errno}
+	}
+	return nil
+}

--- a/lib/fspatch/xattrs_unsupported.go
+++ b/lib/fspatch/xattrs_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package fspatch
+
+import (
+	"polydawn.net/repeatr/def"
+)
+
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	return nil, def.ErrNotSupportedPlatform
+}
+
+func Lsetxattr(path string, attr string, data []byte, flags int) error {
+	return def.ErrNotSupportedPlatform
+}

--- a/output/output.go
+++ b/output/output.go
@@ -1,8 +1,17 @@
 package output
 
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
 type Output interface {
 	// stub
 
 	// See docs for input/input.go ; this is very very presumptory ATM and is liable to violent change.
 	Apply(rootPath string) <-chan error
 }
+
+var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate
+
+// wraps any other unknown errors just to emphasize the system that raised them; any well known errors should use a different type.
+var UnknownError *errors.ErrorClass = Error.NewClass("OutputUnknownError")

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -1,0 +1,56 @@
+package tar2
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"hash"
+
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/lib/fshash"
+	"polydawn.net/repeatr/output"
+)
+
+const Type = "tar"
+
+var _ output.Output = &Output{} // interface assertion
+
+type Output struct {
+	spec          def.Output
+	hasherFactory func() hash.Hash
+}
+
+func New(spec def.Output) *Output {
+	if spec.Type != Type {
+		panic(errors.ProgrammerError.New("This output implementation supports definitions of type %q, not %q", Type, spec.Type))
+	}
+	return &Output{
+		spec:          spec,
+		hasherFactory: sha512.New384,
+	}
+}
+
+func (o Output) Apply(basePath string) <-chan error {
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		try.Do(func() {
+			// walk filesystem, copying and accumulating data for integrity check
+			bucket := &fshash.MemoryBucket{}
+			// TODO STUFF
+
+			// hash whole tree
+			actualTreeHash, _ := fshash.Hash(bucket, o.hasherFactory)
+
+			// report the hash by mutating our spec object.
+			// heh, see the problem there?  pointers
+			o.spec.Hash = base64.URLEncoding.EncodeToString(actualTreeHash)
+		}).CatchAll(func(e error) {
+			// any errors should be caught and forwarded through a channel for management rather than killing the whole sytem unexpectedly.
+			// this could maybe be improved with better error grouping (wrap all errors in a type that indicates origin subsystem and forwards the original as a 'cause' attachement, etc).
+			done <- e
+		}).Done()
+	}()
+	return done
+}

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -1,0 +1,1 @@
+package tar2

--- a/testutil/filefixtures/file_fixtures.go
+++ b/testutil/filefixtures/file_fixtures.go
@@ -13,7 +13,7 @@ import (
 
 var Alpha Fixture = Fixture{"Alpha",
 	[]FixtureFile{
-		{fs.Metadata{Name: "./", Mode: 0755, ModTime: time.Unix(1000, 2000)}, nil},
+		{fs.Metadata{Name: ".", Mode: 0755, ModTime: time.Unix(1000, 2000)}, nil},
 		{fs.Metadata{Name: "./a", Mode: 01777, ModTime: time.Unix(3000, 2000)}, nil},
 		{fs.Metadata{Name: "./b", Mode: 0750, ModTime: time.Unix(5000, 2000)}, nil},
 		{fs.Metadata{Name: "./b/c", Mode: 0664, ModTime: time.Unix(7000, 2000)}, []byte("zyx")},
@@ -22,7 +22,7 @@ var Alpha Fixture = Fixture{"Alpha",
 
 var Beta Fixture = Fixture{"Beta",
 	[]FixtureFile{
-		{fs.Metadata{Name: "./"}, nil},
+		{fs.Metadata{Name: "."}, nil},
 		{fs.Metadata{Name: "./1"}, []byte{}},
 		{fs.Metadata{Name: "./2"}, []byte{}},
 		{fs.Metadata{Name: "./3"}, []byte{}},

--- a/testutil/filefixtures/file_fixtures.go
+++ b/testutil/filefixtures/file_fixtures.go
@@ -1,0 +1,43 @@
+/*
+	Utilities for describing test filesystems, setting them up, and checking
+	that an extant filesystem matches a description.  Only intended to be
+	imported by test code.
+*/
+package filefixture
+
+import (
+	"time"
+
+	"polydawn.net/repeatr/lib/fs"
+)
+
+var Alpha Fixture = Fixture{"Alpha",
+	[]FixtureFile{
+		{fs.Metadata{Name: "./", Mode: 0755, ModTime: time.Unix(1000, 2000)}, nil},
+		{fs.Metadata{Name: "./a", Mode: 01777, ModTime: time.Unix(3000, 2000)}, nil},
+		{fs.Metadata{Name: "./b", Mode: 0750, ModTime: time.Unix(5000, 2000)}, nil},
+		{fs.Metadata{Name: "./b/c", Mode: 0664, ModTime: time.Unix(7000, 2000)}, []byte("zyx")},
+	},
+}
+
+var Beta Fixture = Fixture{"Beta",
+	[]FixtureFile{
+		{fs.Metadata{Name: "./"}, nil},
+		{fs.Metadata{Name: "./1"}, []byte{}},
+		{fs.Metadata{Name: "./2"}, []byte{}},
+		{fs.Metadata{Name: "./3"}, []byte{}},
+	},
+}
+
+var All []Fixture = []Fixture{
+	Alpha,
+	Beta,
+}
+
+func init() {
+	for _, fixture := range All {
+		for i, f := range fixture.Files {
+			fixture.Files[i] = defaults(f)
+		}
+	}
+}

--- a/testutil/filefixtures/file_fixtures.go
+++ b/testutil/filefixtures/file_fixtures.go
@@ -18,7 +18,7 @@ var Alpha Fixture = Fixture{"Alpha",
 		{fs.Metadata{Name: "./b", Mode: 0750, ModTime: time.Unix(5000, 2000)}, nil},
 		{fs.Metadata{Name: "./b/c", Mode: 0664, ModTime: time.Unix(7000, 2000)}, []byte("zyx")},
 	},
-}
+}.defaults()
 
 var Beta Fixture = Fixture{"Beta",
 	[]FixtureFile{
@@ -27,17 +27,9 @@ var Beta Fixture = Fixture{"Beta",
 		{fs.Metadata{Name: "./2"}, []byte{}},
 		{fs.Metadata{Name: "./3"}, []byte{}},
 	},
-}
+}.defaults()
 
 var All []Fixture = []Fixture{
 	Alpha,
 	Beta,
-}
-
-func init() {
-	for _, fixture := range All {
-		for i, f := range fixture.Files {
-			fixture.Files[i] = defaults(f)
-		}
-	}
 }

--- a/testutil/filefixtures/file_fixtures.go
+++ b/testutil/filefixtures/file_fixtures.go
@@ -29,6 +29,15 @@ var Beta Fixture = Fixture{"Beta",
 	},
 }.defaults()
 
+var Breakout Fixture = Fixture{"Breakout",
+	[]FixtureFile{
+		{fs.Metadata{Name: "."}, nil},
+		{fs.Metadata{Name: "./danger", Linkname: "/tmp"}, nil},
+		{fs.Metadata{Name: "./danger/dangerzone"}, nil},
+		{fs.Metadata{Name: "./danger/dangerzone/laaaaanaaa"}, []byte("WHAT")},
+	},
+}.defaults() // this is *not* included in `All` because it's actually a little scary.
+
 var All []Fixture = []Fixture{
 	Alpha,
 	Beta,

--- a/testutil/filefixtures/file_fixtures_test.go
+++ b/testutil/filefixtures/file_fixtures_test.go
@@ -2,9 +2,11 @@ package filefixture
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/testutil"
 )
 
@@ -33,4 +35,22 @@ func Test(t *testing.T) {
 			}))
 		}
 	})
+
+	testutil.Convey_IfHaveRoot("Symlink breakouts should be refuted", t, FailureContinues, testutil.WithTmpdir(func() {
+		// this is a sketchy, unsandboxed test.
+		// I hope you don't have anything in /tmp/dangerzone, and/or that you're running the entire suite in a vm.
+		os.RemoveAll("/tmp/dangerzone")
+		Convey("With a relative basepath", func() {
+			So(func() { Breakout.Create(".") }, testutil.ShouldPanicWith, fs.BreakoutError)
+			_, err := os.Stat("/tmp/dangerzone/laaaaanaaa")
+			So(err, ShouldNotBeNil) // if nil err, oh my god, it exists
+		})
+		Convey("With an absolute basepath", func() {
+			pwd, err := os.Getwd()
+			So(err, ShouldBeNil)
+			So(func() { Breakout.Create(pwd) }, testutil.ShouldPanicWith, fs.BreakoutError)
+			_, err = os.Stat("/tmp/dangerzone/laaaaanaaa")
+			So(err, ShouldNotBeNil) // if nil err, oh my god, it exists
+		})
+	}))
 }

--- a/testutil/filefixtures/file_fixtures_test.go
+++ b/testutil/filefixtures/file_fixtures_test.go
@@ -9,6 +9,11 @@ import (
 )
 
 func Test(t *testing.T) {
+	Convey("Describe fixture Beta", t, func() {
+		Println() // goconvey seems to do alignment rong in cli out of box :I
+		Println(Beta.Describe(CompareAll))
+	})
+
 	testutil.Convey_IfHaveRoot("Checking that fixtures can apply", t, func() {
 		for _, fixture := range All {
 			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {

--- a/testutil/filefixtures/file_fixtures_test.go
+++ b/testutil/filefixtures/file_fixtures_test.go
@@ -1,0 +1,20 @@
+package filefixture
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/testutil"
+)
+
+func Test(t *testing.T) {
+	testutil.Convey_IfHaveRoot("Checking that fixtures can apply", t, func() {
+		for _, fixture := range All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				fixture.Create(".")
+				So(true, ShouldBeTrue) // reaching here is success
+			}))
+		}
+	})
+}

--- a/testutil/filefixtures/file_fixtures_test.go
+++ b/testutil/filefixtures/file_fixtures_test.go
@@ -9,16 +9,27 @@ import (
 )
 
 func Test(t *testing.T) {
-	Convey("Describe fixture Beta", t, func() {
-		Println() // goconvey seems to do alignment rong in cli out of box :I
-		Println(Beta.Describe(CompareAll))
-	})
+	// uncomment for an example output
+	//	Convey("Describe fixture Beta", t, func() {
+	//		Println() // goconvey seems to do alignment rong in cli out of box :I
+	//		Println(Beta.Describe(CompareAll))
+	//	})
 
-	testutil.Convey_IfHaveRoot("Checking that fixtures can apply", t, func() {
+	testutil.Convey_IfHaveRoot("All fixtures should be able to apply their content to an empty dir", t, func() {
 		for _, fixture := range All {
 			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
 				fixture.Create(".")
 				So(true, ShouldBeTrue) // reaching here is success
+			}))
+		}
+	})
+
+	testutil.Convey_IfHaveRoot("Applying a fixture and rescanning it should produce identical descriptions", t, func() {
+		for _, fixture := range All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				fixture.Create(".")
+				reheat := Scan(".")
+				So(reheat.Describe(CompareDefaults), ShouldEqual, fixture.Describe(CompareDefaults))
 			}))
 		}
 	})

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -93,6 +93,13 @@ func (ffs Fixture) Create(basePath string) {
 	for _, f := range ffs.Files {
 		fs.PlaceFile(basePath, f.Metadata, bytes.NewBuffer(f.Body))
 	}
+	// re-do time enforcement... in reverse order, so we cover our own tracks
+	for i := len(ffs.Files) - 1; i >= 0; i-- {
+		f := ffs.Files[i]
+		if f.Metadata.Typeflag == tar.TypeDir {
+			fs.PlaceDirTime(basePath, f.Metadata)
+		}
+	}
 }
 
 /*
@@ -159,8 +166,8 @@ func (ff FixtureFile) Describe(opts ComparisonOptions) string {
 		{"Name:%q", ff.Metadata.Name},
 		{"Type:%q", ff.Metadata.Typeflag},
 		{"Perms:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.FileMode()})[opts&ComparePerms == 0]},
-		{"Mtime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.ModTime})[opts&CompareMtime == 0]},
-		{"Atime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.AccessTime})[opts&CompareAtime == 0]},
+		{"Mtime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.ModTime.UTC()})[opts&CompareMtime == 0]},
+		{"Atime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.AccessTime.UTC()})[opts&CompareAtime == 0]},
 		{"Uid:%d", (map[bool]interface{}{true: "-", false: ff.Metadata.Uid})[opts&CompareUid == 0]},
 		{"Gid:%d", (map[bool]interface{}{true: "-", false: ff.Metadata.Gid})[opts&CompareGid == 0]},
 		{"DM:%d", ff.Metadata.Devmajor},

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -118,13 +117,12 @@ func Scan(basePath string) Fixture {
 		if filenode.Err != nil {
 			return filenode.Err
 		}
-		fullPath := filepath.Join(basePath, filenode.Path)
-		hdr := fs.ReadMetadata(fullPath, filenode.Info)
-		hdr.Name = filenode.Path
+		hdr, file := fs.ScanFile(basePath, filenode.Path)
 		var body []byte
-		if hdr.Typeflag == tar.TypeReg {
+		if file != nil {
+			defer file.Close()
 			var err error
-			body, err = ioutil.ReadFile(fullPath)
+			body, err = ioutil.ReadAll(file)
 			if err != nil {
 				return err
 			}

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -126,38 +126,16 @@ func (ff FixtureFile) Describe(opts ComparisonOptions) string {
 	}{
 		{"Name:%q", ff.Metadata.Name},
 		{"Type:%q", ff.Metadata.Typeflag},
-		{"Perms:%q", ff.Metadata.FileMode()},
-		{"Mtime:%q", ff.Metadata.ModTime},
-		{"Atime:%q", ff.Metadata.AccessTime},
-		{"Uid:%d", ff.Metadata.Uid},
-		{"Gid:%d", ff.Metadata.Gid},
+		{"Perms:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.FileMode()})[opts&ComparePerms == 0]},
+		{"Mtime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.ModTime})[opts&CompareMtime == 0]},
+		{"Atime:%q", (map[bool]interface{}{true: "-", false: ff.Metadata.AccessTime})[opts&CompareAtime == 0]},
+		{"Uid:%d", (map[bool]interface{}{true: "-", false: ff.Metadata.Uid})[opts&CompareUid == 0]},
+		{"Gid:%d", (map[bool]interface{}{true: "-", false: ff.Metadata.Gid})[opts&CompareGid == 0]},
 		{"DM:%d", ff.Metadata.Devmajor},
 		{"Dm:%d", ff.Metadata.Devminor},
 		{"Link:%q", ff.Metadata.Linkname},
-		{"Size:%d", ff.Metadata.Size},
-		{"Body:%q", ff.Body},
-	}
-	// my kingdom for a ternary operator
-	if opts&ComparePerms == 0 {
-		parts[2].Value = "-"
-	}
-	if opts&CompareMtime == 0 {
-		parts[3].Value = "-"
-	}
-	if opts&CompareAtime == 0 {
-		parts[4].Value = "-"
-	}
-	if opts&CompareUid == 0 {
-		parts[5].Value = "-"
-	}
-	if opts&CompareGid == 0 {
-		parts[6].Value = "-"
-	}
-	if opts&CompareSize == 0 {
-		parts[10].Value = "-"
-	}
-	if opts&CompareBody == 0 {
-		parts[11].Value = "-"
+		{"Size:%d", (map[bool]interface{}{true: "-", false: ff.Metadata.Size})[opts&CompareSize == 0]},
+		{"Body:%q", (map[bool]interface{}{true: "-", false: ff.Body})[opts&CompareBody == 0]},
 	}
 	var pattern string
 	var values []interface{}

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -1,0 +1,97 @@
+package filefixture
+
+import (
+	"archive/tar"
+	"bytes"
+	"strings"
+	"time"
+
+	"polydawn.net/repeatr/lib/fs"
+)
+
+type FixtureFile struct {
+	Metadata fs.Metadata
+	Body     []byte
+}
+
+type Fixture struct {
+	Name  string
+	Files []FixtureFile
+}
+
+func defaults(f FixtureFile) FixtureFile {
+	if f.Metadata.Typeflag == '\x00' {
+		if f.Body == nil {
+			f.Metadata.Typeflag = tar.TypeDir
+		} else {
+			f.Metadata.Typeflag = tar.TypeReg
+		}
+	}
+	if f.Metadata.Mode == 0 {
+		switch f.Metadata.Typeflag {
+		case tar.TypeDir:
+			f.Metadata.Mode = 0755
+		default:
+			f.Metadata.Mode = 0644
+		}
+	}
+	if f.Metadata.Uid == 0 {
+		f.Metadata.Uid = 10000
+	}
+	if f.Metadata.Gid == 0 {
+		f.Metadata.Gid = 10000
+	}
+	if f.Metadata.ModTime.IsZero() {
+		f.Metadata.ModTime = time.Unix(0, 0).UTC()
+	}
+	if f.Metadata.AccessTime.IsZero() {
+		f.Metadata.AccessTime = time.Unix(0, 0).UTC()
+	}
+	return f
+}
+
+/*
+	Create files described by the fixtures on the real filesystem path given.
+*/
+func (ffs Fixture) Create(basePath string) {
+	for _, f := range ffs.Files {
+		fs.PlaceFile(basePath, f.Metadata, bytes.NewBuffer(f.Body))
+	}
+}
+
+/*
+	Scan a real filesystem and see it as fixture file descriptions.
+	Usually used as a prelude to a pair of `Describe` calls followed by
+	an equality assertion.
+
+	Note that this loads all file bodies into memory at once, so it
+	is not wise to use on large filesystems.
+
+	Result will be sorted by filename, as per usual.
+*/
+func Scan(basePath string) Fixture {
+	return Fixture{} // TODO
+}
+
+/*
+	Produces a string where every line describes a one entry in the
+	set of file descriptions.  This is useful for handing into "ShouldResemble"
+	assertions, which will not only pass/fail but do character diffs which
+	effectively cover the whole structure in one shot.
+
+
+*/
+func (ffs Fixture) Describe() string {
+	lines := make([]string, len(ffs.Files))
+	for i, f := range ffs.Files {
+		lines[i] = f.Describe()
+	}
+	return strings.Join(lines, "\n")
+}
+
+/*
+	As per `FixtureFiles.Describe`, but this is for a single entry.
+*/
+func (ff FixtureFile) Describe() string {
+	return "" // TODO
+}

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spacemonkeygo/errors"
 	"polydawn.net/repeatr/lib/fs"
 )
 
@@ -94,6 +95,10 @@ func defaults(f FixtureFile) FixtureFile {
 	Create files described by the fixtures on the real filesystem path given.
 */
 func (ffs Fixture) Create(basePath string) {
+	basePath, err := filepath.Abs(basePath)
+	if err != nil {
+		panic(errors.IOError.Wrap(err))
+	}
 	for _, f := range ffs.Files {
 		fs.PlaceFile(basePath, f.Metadata, bytes.NewBuffer(f.Body))
 	}

--- a/testutil/filefixtures/types.go
+++ b/testutil/filefixtures/types.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -54,7 +55,11 @@ func (f Fixture) defaults() Fixture {
 func defaults(f FixtureFile) FixtureFile {
 	if f.Metadata.Typeflag == '\x00' {
 		if f.Body == nil {
-			f.Metadata.Typeflag = tar.TypeDir
+			if f.Metadata.Linkname != "" {
+				f.Metadata.Typeflag = tar.TypeSymlink
+			} else {
+				f.Metadata.Typeflag = tar.TypeDir
+			}
 		} else {
 			f.Metadata.Typeflag = tar.TypeReg
 		}


### PR DESCRIPTION
More IO, and tons of work on a smarter arrangement test fixtures.

The new test system is based on spec'ing out files in memory, easily placing them in filesystem or scanning filesystem contents to get the descriptions back, and then having tunable precision comparisons.  It's also extremely terse (jump to `testutil/filefixtures/file_fixtures.go` for the diff of glory), which is fortunate because of lot of tests so far have grown really big setups and it was starting to hinder test creation.  In the future these `Fixture` objects may  also hold other self-describing data so they can be plugged into table-driven tests.

Several refactors that became apparent on the way included (filesystem walking and the metadata structures are moved into the new `lib/fs` package, and 'lib/fshash' is now *just* the hashing components plugged into the fs walker, etc)... See the individual commit log for more; those diffs should be individually readable.

:warning: WIP :warning: -- this is one big semicontinuous landslide that will also probably still yield a pure golang tar input and hashed tar output system before it comes to rest, because all these systems just have so much overlap.  Not all prior tests are replaced yet; that can be a slow churn process.