### PR TITLE
Tar output

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule ".gopath/src/github.com/smartystreets/assertions"]
 	path = .gopath/src/github.com/smartystreets/assertions
 	url = http://github.com/smartystreets/assertions
+[submodule ".gopath/src/github.com/polydawn/gosh"]
+	path = .gopath/src/github.com/polydawn/gosh
+	url = https://github.com/polydawn/gosh.git

--- a/lib/flak/provision.go
+++ b/lib/flak/provision.go
@@ -53,13 +53,12 @@ func PreserveOutputs(outputs []def.Output, rootfs string) []def.Output {
 		Println("Persisting output", x+1, output.Type, "from", output.Location)
 		// path := filepath.Join(rootfs, output.Location)
 
-		err := <-outputdispatch.Get(output).Apply(rootfs)
-		if err != nil {
-			Println("Output", x+1, "failed:", err)
-			panic(err)
+		report := <-outputdispatch.Get(output).Apply(rootfs)
+		if report.Err != nil {
+			Println("Output", x+1, "failed:", report.Err)
+			panic(report.Err)
 		}
-
-		// TODO: doesn't get hash info, etc
+		Println("Output", x+1, "hash:", report.Output.Hash)
 	}
 
 	return outputs

--- a/output/dir/dir_output.go
+++ b/output/dir/dir_output.go
@@ -1,0 +1,62 @@
+package dir
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"hash"
+
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/lib/fshash"
+	"polydawn.net/repeatr/output"
+)
+
+const Type = "dir"
+
+var _ output.Output = &Output{} // interface assertion
+
+type Output struct {
+	spec          def.Output
+	hasherFactory func() hash.Hash
+}
+
+func New(spec def.Output) output.Output {
+	if spec.Type != Type {
+		panic(errors.ProgrammerError.New("This output implementation supports definitions of type %q, not %q", Type, spec.Type))
+	}
+	return &Output{
+		spec:          spec,
+		hasherFactory: sha512.New384,
+	}
+}
+
+func (o Output) Apply(basePath string) <-chan output.Report {
+	done := make(chan output.Report)
+	go func() {
+		defer close(done)
+
+		try.Do(func() {
+			// walk filesystem, copying and accumulating data for integrity check
+			bucket := &fshash.MemoryBucket{}
+			err := fshash.FillBucket(basePath, o.spec.URI, bucket, o.hasherFactory)
+			if err != nil {
+				panic(err)
+			}
+
+			// hash whole tree
+			actualTreeHash, _ := fshash.Hash(bucket, o.hasherFactory)
+
+			// report
+			o.spec.Hash = base64.URLEncoding.EncodeToString(actualTreeHash)
+			done <- output.Report{nil, o.spec}
+		}).Catch(output.Error, func(err *errors.Error) {
+			done <- output.Report{err, def.Output{}}
+		}).CatchAll(func(err error) {
+			// All errors we emit will be under `output.Error`'s type.
+			// Every time we hit this UnknownError path, we should consider it a bug until that error is categorized.
+			done <- output.Report{output.UnknownError.Wrap(err).(*errors.Error), def.Output{}}
+		}).Done()
+	}()
+	return done
+}

--- a/output/dir/dir_output_test.go
+++ b/output/dir/dir_output_test.go
@@ -1,0 +1,13 @@
+package dir
+
+import (
+	"testing"
+
+	"polydawn.net/repeatr/output/tests"
+)
+
+func TestCoreCompliance(t *testing.T) {
+	tests.CheckScanWithoutMutation(t, "dir", New)
+	tests.CheckScanProducesConsistentHash(t, "dir", New)
+	tests.CheckScanProducesDistinctHashes(t, "dir", New)
+}

--- a/output/errors.go
+++ b/output/errors.go
@@ -1,0 +1,23 @@
+package output
+
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
+var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate
+
+/*
+	Indicates that the target filesystem (the one given to `Apply`) had some error.
+*/
+var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("TargetFilesystemUnavailableError")
+
+// Convenience method for wrapping io errors.
+func TargetFilesystemUnavailableIOError(err error) *errors.Error {
+	return TargetFilesystemUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
+}
+
+/*
+	Wraps any other unknown errors just to emphasize the system that raised them;
+	any well known errors should use a different type.
+*/
+var UnknownError *errors.ErrorClass = Error.NewClass("OutputUnknownError")

--- a/output/output.go
+++ b/output/output.go
@@ -17,5 +17,15 @@ type Report struct {
 
 var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate
 
+/*
+	Indicates that the target filesystem (the one given to `Apply`) had some error.
+*/
+var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("TargetFilesystemUnavailableError")
+
+// Convenience method for wrapping io errors.
+func TargetFilesystemUnavailableIOError(err error) *errors.Error {
+	return TargetFilesystemUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
+}
+
 // wraps any other unknown errors just to emphasize the system that raised them; any well known errors should use a different type.
 var UnknownError *errors.ErrorClass = Error.NewClass("OutputUnknownError")

--- a/output/output.go
+++ b/output/output.go
@@ -2,13 +2,17 @@ package output
 
 import (
 	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/def"
 )
 
 type Output interface {
-	// stub
-
 	// See docs for input/input.go ; this is very very presumptory ATM and is liable to violent change.
-	Apply(rootPath string) <-chan error
+	Apply(rootPath string) <-chan Report
+}
+
+type Report struct {
+	Err    *errors.Error // error, or nil if success.  All errors will be under `output.Error`'s type.
+	Output def.Output    // this comes back with the Hash field set
 }
 
 var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate

--- a/output/output.go
+++ b/output/output.go
@@ -14,18 +14,3 @@ type Report struct {
 	Err    *errors.Error // error, or nil if success.  All errors will be under `output.Error`'s type.
 	Output def.Output    // this comes back with the Hash field set
 }
-
-var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate
-
-/*
-	Indicates that the target filesystem (the one given to `Apply`) had some error.
-*/
-var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("TargetFilesystemUnavailableError")
-
-// Convenience method for wrapping io errors.
-func TargetFilesystemUnavailableIOError(err error) *errors.Error {
-	return TargetFilesystemUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
-}
-
-// wraps any other unknown errors just to emphasize the system that raised them; any well known errors should use a different type.
-var UnknownError *errors.ErrorClass = Error.NewClass("OutputUnknownError")

--- a/output/tar/tar_output.go
+++ b/output/tar/tar_output.go
@@ -38,6 +38,7 @@ func (i Output) Apply(rootPath string) <-chan output.Report {
 		err := os.MkdirAll(rootPath, 0777)
 		if err != nil {
 			done <- output.Report{errors.IOError.Wrap(err).(*errors.Error), def.Output{}}
+			return
 		}
 
 		// Assumes output URI is a folder. Output transport impls should obviously be more robust

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -25,7 +25,7 @@ type Output struct {
 	hasherFactory func() hash.Hash
 }
 
-func New(spec def.Output) *Output {
+func New(spec def.Output) output.Output {
 	if spec.Type != Type {
 		panic(errors.ProgrammerError.New("This output implementation supports definitions of type %q, not %q", Type, spec.Type))
 	}

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -45,6 +45,7 @@ func (o Output) Apply(basePath string) <-chan output.Report {
 			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0755)
 			if err != nil {
 				done <- output.Report{errors.IOError.Wrap(err).(*errors.Error), def.Output{}}
+				return
 			}
 			defer file.Close()
 

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -1,13 +1,17 @@
 package tar2
 
 import (
+	"archive/tar"
 	"crypto/sha512"
 	"encoding/base64"
 	"hash"
+	"io"
+	"os"
 
 	"github.com/spacemonkeygo/errors"
 	"github.com/spacemonkeygo/errors/try"
 	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/fshash"
 	"polydawn.net/repeatr/output"
 )
@@ -36,9 +40,22 @@ func (o Output) Apply(basePath string) <-chan error {
 	go func() {
 		defer close(done)
 		try.Do(func() {
+			// open output location for writing
+			// currently this impl assumes a local file uri
+			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0755)
+			if err != nil {
+				panic(errors.IOError.Wrap(err))
+			}
+			defer file.Close()
+
 			// walk filesystem, copying and accumulating data for integrity check
 			bucket := &fshash.MemoryBucket{}
-			// TODO STUFF
+			tarWriter := tar.NewWriter(file)
+			defer tarWriter.Close()
+			if err := walk(basePath, tarWriter, bucket, o.hasherFactory); err != nil {
+				done <- err
+				return
+			}
 
 			// hash whole tree
 			actualTreeHash, _ := fshash.Hash(bucket, o.hasherFactory)
@@ -55,4 +72,29 @@ func (o Output) Apply(basePath string) <-chan error {
 		}).Done()
 	}()
 	return done
+}
+
+func walk(srcBasePath string, tw *tar.Writer, bucket fshash.Bucket, hasherFactory func() hash.Hash) error {
+	preVisit := func(filenode *fs.FilewalkNode) error {
+		if filenode.Err != nil {
+			return filenode.Err
+		}
+		hdr, file := fs.ScanFile(srcBasePath, filenode.Path, filenode.Info)
+		wat := tar.Header(hdr) // this line is... we're not gonna talk about this.
+		tw.WriteHeader(&wat)
+		if file == nil {
+			bucket.Record(hdr, nil)
+		} else {
+			defer file.Close()
+			hasher := hasherFactory()
+			tee := io.MultiWriter(tw, hasher)
+			_, err := io.Copy(tee, file)
+			if err != nil {
+				return err
+			}
+			bucket.Record(hdr, hasher.Sum(nil))
+		}
+		return nil
+	}
+	return fs.Walk(srcBasePath, preVisit, nil)
 }

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -8,4 +8,6 @@ import (
 
 func Test(t *testing.T) {
 	tests.CheckScanWithoutMutation(t, "tar", New)
+	tests.CheckScanProducesConsistentHash(t, "tar", New)
+	tests.CheckScanProducesDistinctHashes(t, "tar", New)
 }

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -1,1 +1,16 @@
 package tar2
+
+import (
+	"testing"
+
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/output/tests"
+)
+
+func Test(t *testing.T) {
+	tests.CheckScanWithoutMutation(t, New(def.Output{
+		Type:     "tar",
+		Location: "./data",
+		URI:      "./output.tar",
+	}))
+}

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -3,14 +3,9 @@ package tar2
 import (
 	"testing"
 
-	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/output/tests"
 )
 
 func Test(t *testing.T) {
-	tests.CheckScanWithoutMutation(t, New(def.Output{
-		Type:     "tar",
-		Location: "./data",
-		URI:      "./output.tar",
-	}))
+	tests.CheckScanWithoutMutation(t, "tar", New)
 }

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -1,13 +1,55 @@
 package tar2
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/polydawn/gosh"
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/output/tests"
+	"polydawn.net/repeatr/testutil"
+	"polydawn.net/repeatr/testutil/filefixture"
 )
 
-func Test(t *testing.T) {
+func TestCoreCompliance(t *testing.T) {
 	tests.CheckScanWithoutMutation(t, "tar", New)
 	tests.CheckScanProducesConsistentHash(t, "tar", New)
 	tests.CheckScanProducesDistinctHashes(t, "tar", New)
+}
+
+func TestTarCompat(t *testing.T) {
+	testutil.Convey_IfHaveRoot("Applying the output to a filesystem should produce a tar file", t, func() {
+		for _, fixture := range filefixture.All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				subject := New(def.Output{
+					Type: "tar",
+					URI:  "./output.tar",
+				})
+				fixture.Create("./data")
+				report := <-subject.Apply("./data")
+				// sanity check that it worked, and that there's a file.
+				So(report.Err, ShouldBeNil)
+				So("./output.tar", testutil.ShouldBeFile, os.FileMode(0))
+				// now exec tar, and check that it doesn't barf outright.
+				// this is not well isolated from the host; consider improving that a todo.
+				os.Mkdir("./untar", 0755)
+				tarProc := gosh.Gosh(
+					"tar",
+					"-xf", "./output.tar",
+					"-C", "./untar",
+					gosh.NullIO,
+				).RunAndReport()
+				So(tarProc.GetExitCode(), ShouldEqual, 0)
+				// should look roughly the same again even bounced through
+				// some third-party tar implementation, one would hope.
+				rescan := filefixture.Scan("./untar")
+				// boy, that's entertaining though: gnu tar does all the same stuff,
+				// except it doesn't honor our nanosecond timings.
+				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareMtime
+				So(rescan.Describe(comparisonLevel), ShouldResemble, fixture.Describe(comparisonLevel))
+			}))
+		}
+	})
 }

--- a/output/tests/output_tests.go
+++ b/output/tests/output_tests.go
@@ -49,14 +49,14 @@ func CheckScanProducesConsistentHash(t *testing.T, kind string, newOutput Output
 				}))
 				report1 := <-scanner1.Apply("./data")
 				So(report1.Err, ShouldBeNil)
-				os.Remove("./output.dump")
+				os.RemoveAll("./output.dump")
 				scanner2 := newOutput((def.Output{
 					Type: kind,
 					URI:  "./output.dump",
 				}))
 				report2 := <-scanner2.Apply("./data")
 				So(report2.Err, ShouldBeNil)
-				os.Remove("./output.dump")
+				os.RemoveAll("./output.dump")
 				So(report2.Output.Hash, ShouldEqual, report1.Output.Hash)
 			}))
 		}
@@ -73,14 +73,14 @@ func CheckScanProducesDistinctHashes(t *testing.T, kind string, newOutput Output
 		}))
 		report1 := <-scanner1.Apply("./alpha")
 		So(report1.Err, ShouldBeNil)
-		os.Remove("./output.dump")
+		os.RemoveAll("./output.dump")
 		scanner2 := newOutput((def.Output{
 			Type: kind,
 			URI:  "./output.dump",
 		}))
 		report2 := <-scanner2.Apply("./beta")
 		So(report2.Err, ShouldBeNil)
-		os.Remove("./output.dump")
+		os.RemoveAll("./output.dump")
 		So(report2.Output.Hash, ShouldEqual, report1.Output.Hash)
 	}))
 }

--- a/output/tests/output_tests.go
+++ b/output/tests/output_tests.go
@@ -37,3 +37,50 @@ func CheckScanWithoutMutation(t *testing.T, kind string, newOutput OutputFactory
 		}
 	})
 }
+
+func CheckScanProducesConsistentHash(t *testing.T, kind string, newOutput OutputFactory) {
+	testutil.Convey_IfHaveRoot("Applying the output to a filesystem twice should produce the same hash", t, func() {
+		for _, fixture := range filefixture.All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				fixture.Create("./data")
+				scanner1 := newOutput((def.Output{
+					Type: kind,
+					URI:  "./output.dump",
+				}))
+				report1 := <-scanner1.Apply("./data")
+				So(report1.Err, ShouldBeNil)
+				os.Remove("./output.dump")
+				scanner2 := newOutput((def.Output{
+					Type: kind,
+					URI:  "./output.dump",
+				}))
+				report2 := <-scanner2.Apply("./data")
+				So(report2.Err, ShouldBeNil)
+				os.Remove("./output.dump")
+				So(report2.Output.Hash, ShouldEqual, report1.Output.Hash)
+			}))
+		}
+	})
+}
+
+func CheckScanProducesDistinctHashes(t *testing.T, kind string, newOutput OutputFactory) {
+	testutil.Convey_IfHaveRoot("Applying the output to two different filesystems should produce different hashes", t, testutil.WithTmpdir(func() {
+		filefixture.Alpha.Create("./alpha")
+		filefixture.Alpha.Create("./beta")
+		scanner1 := newOutput((def.Output{
+			Type: kind,
+			URI:  "./output.dump",
+		}))
+		report1 := <-scanner1.Apply("./alpha")
+		So(report1.Err, ShouldBeNil)
+		os.Remove("./output.dump")
+		scanner2 := newOutput((def.Output{
+			Type: kind,
+			URI:  "./output.dump",
+		}))
+		report2 := <-scanner2.Apply("./beta")
+		So(report2.Err, ShouldBeNil)
+		os.Remove("./output.dump")
+		So(report2.Output.Hash, ShouldEqual, report1.Output.Hash)
+	}))
+}

--- a/output/tests/output_tests.go
+++ b/output/tests/output_tests.go
@@ -10,15 +10,23 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/output"
 	"polydawn.net/repeatr/testutil"
 	"polydawn.net/repeatr/testutil/filefixture"
 )
 
-func CheckScanWithoutMutation(t *testing.T, subject output.Output) {
+type OutputFactory func(def.Output) output.Output
+
+func CheckScanWithoutMutation(t *testing.T, kind string, newOutput OutputFactory) {
 	testutil.Convey_IfHaveRoot("Applying the output to a filesystem shouldn't change it", t, func() {
 		for _, fixture := range filefixture.All {
 			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				subject := newOutput((def.Output{
+					Type:     kind,
+					Location: "./data",
+					URI:      "./output.dump", // assumes your output supports local file for throwaway :/
+				}))
 				fixture.Create("./data")
 				So(<-subject.Apply("./data"), ShouldBeNil)
 				rescan := filefixture.Scan("./data")

--- a/output/tests/output_tests.go
+++ b/output/tests/output_tests.go
@@ -7,6 +7,7 @@ package tests
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -23,12 +24,13 @@ func CheckScanWithoutMutation(t *testing.T, kind string, newOutput OutputFactory
 		for _, fixture := range filefixture.All {
 			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
 				subject := newOutput((def.Output{
-					Type:     kind,
-					Location: "./data",
-					URI:      "./output.dump", // assumes your output supports local file for throwaway :/
+					Type: kind,
+					URI:  "./output.dump", // assumes your output supports local file for throwaway :/
 				}))
 				fixture.Create("./data")
-				So(<-subject.Apply("./data"), ShouldBeNil)
+				report := <-subject.Apply("./data")
+				So(report.Err, ShouldBeNil)
+				os.Remove("./output.dump")
 				rescan := filefixture.Scan("./data")
 				So(rescan.Describe(filefixture.CompareDefaults), ShouldResemble, fixture.Describe(filefixture.CompareDefaults))
 			}))

--- a/output/tests/output_tests.go
+++ b/output/tests/output_tests.go
@@ -1,0 +1,29 @@
+/*
+	Tests for use in each output implementation.
+	Import and invoke in each implementation's package to get coverage
+	within that package.
+*/
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/output"
+	"polydawn.net/repeatr/testutil"
+	"polydawn.net/repeatr/testutil/filefixture"
+)
+
+func CheckScanWithoutMutation(t *testing.T, subject output.Output) {
+	testutil.Convey_IfHaveRoot("Applying the output to a filesystem shouldn't change it", t, func() {
+		for _, fixture := range filefixture.All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), testutil.WithTmpdir(func() {
+				fixture.Create("./data")
+				So(<-subject.Apply("./data"), ShouldBeNil)
+				rescan := filefixture.Scan("./data")
+				So(rescan.Describe(filefixture.CompareDefaults), ShouldResemble, fixture.Describe(filefixture.CompareDefaults))
+			}))
+		}
+	})
+}


### PR DESCRIPTION
Add a hashing tar output implementation.

This hashing tar output implementation is happily tiny: treewalk and fshash.bucket stuff was totally reusable, as intended... so basically all that needed to happen here was wiring the file body io streams.

Interfaces extended to support the new data returns.

Includes a new test package which uses the file fixtures, and itself refers only to the output interface -- zero references to the tar (or any other) implementation.  So these can be reused by every output implementation in the future!  All hail the table-driven specs.