### PR TITLE
Schedulers!

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -32,7 +32,7 @@ func LoadFormulaFromFile(path string) def.Formula {
 	return formula
 }
 
-func RunFormulae(s scheduler.Scheduler, e *executor.Executor, f ...def.Formula) {
+func RunFormulae(s scheduler.Scheduler, e executor.Executor, f ...def.Formula) {
 	s.Configure(e)
 	s.Start()
 

--- a/cli/run.go
+++ b/cli/run.go
@@ -32,9 +32,9 @@ func LoadFormulaFromFile(path string) def.Formula {
 	return formula
 }
 
-func RunFormulae(s *scheduler.Scheduler, e *executor.Executor, f ...def.Formula) {
-	(*s).Configure(e)
-	(*s).Start()
+func RunFormulae(s scheduler.Scheduler, e *executor.Executor, f ...def.Formula) {
+	s.Configure(e)
+	s.Start()
 
 	var wg sync.WaitGroup
 
@@ -44,7 +44,7 @@ func RunFormulae(s *scheduler.Scheduler, e *executor.Executor, f ...def.Formula)
 
 		go func() {
 			defer wg.Done()
-			job := <- (*s).Schedule(formula)
+			job := <-s.Schedule(formula)
 
 			Println("Job", x, job.Id(), "queued")
 			result := job.Wait()

--- a/cli/run.go
+++ b/cli/run.go
@@ -33,7 +33,7 @@ func LoadFormulaFromFile(path string) def.Formula {
 }
 
 func RunFormulae(s scheduler.Scheduler, e executor.Executor, f ...def.Formula) {
-	s.Configure(e)
+	s.Configure(e, len(f)) // we know exactly how many forumlae will be enqueued
 	s.Start()
 
 	var wg sync.WaitGroup

--- a/cli/run.go
+++ b/cli/run.go
@@ -44,10 +44,10 @@ func RunFormulae(s scheduler.Scheduler, e executor.Executor, f ...def.Formula) {
 
 		// gofunc + range = race condition, whoops!
 		n := x + 1
+		id, jobChan := s.Schedule(formula)
 
 		go func() {
 			defer wg.Done()
-			id, jobChan := s.Schedule(formula)
 
 			Println("Job", n, id, "queued")
 			job := <-jobChan

--- a/cli/run.go
+++ b/cli/run.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	. "fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"github.com/ugorji/go/codec"
+
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/scheduler"
+)
+
+func LoadFormulaFromFile(path string) def.Formula {
+	filename, _ := filepath.Abs(path)
+
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		Println(err)
+		Println("Could not read file", filename)
+		os.Exit(1)
+	}
+
+	dec := codec.NewDecoderBytes(content, &codec.JsonHandle{})
+
+	formula := def.Formula{}
+	dec.MustDecode(&formula)
+
+	return formula
+}
+
+func RunFormulae(s *scheduler.Scheduler, e *executor.Executor, f ...def.Formula) {
+	try.Do(func() {
+
+		(*s).Configure(e)
+		(*s).Start()
+
+		// Queue each job as the scheduler deigns to read from the channel
+		go func() {
+			for _, formula := range f {
+				(*s).Queue() <- formula
+			}
+		}()
+
+		exitCode := 0
+
+		// Get job results in order
+		// Could obviously be improved by out-of-order
+		for x := 0; x < len(f); x++ {
+			if len(f) > 1 {
+				Println("Running formula", x+1)
+			}
+			job := <-(*s).Results()
+			result := job.Wait()
+
+			Println("Job finished with code", result.ExitCode, "Outputs:", result.Outputs)
+
+			if result.Error != nil {
+				Println("Problem executing job:", result.Error)
+			}
+		}
+
+		// DISCUSS: we could consider any non-zero exit a Error, but having that distinct from execution problems makes sense.
+		// This is clearly silly and placeholder.
+		os.Exit(exitCode)
+
+	}).Catch(def.ValidationError, func(e *errors.Error) {
+		// TODO: I think this is off the goroutine now, whelp
+		Println(e.Message())
+		os.Exit(2)
+	}).Done()
+}

--- a/executor/basicjob/basic.go
+++ b/executor/basicjob/basic.go
@@ -4,7 +4,6 @@ import (
 	"io"
 
 	"polydawn.net/repeatr/def"
-	"polydawn.net/repeatr/lib/guid"
 )
 
 type BasicJob struct {
@@ -32,13 +31,9 @@ func (j *BasicJob) Wait() def.JobResult {
 	return j.Result
 }
 
-func New() *BasicJob {
-
-	gid := def.JobID(guid.New())
-
+func New(id def.JobID) *BasicJob {
 	return &BasicJob{
-		ID:       gid,
+		ID:       id,
 		WaitChan: make(chan struct{}),
 	}
-
 }

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -27,11 +27,11 @@ func (e *Executor) Configure(workspacePath string) {
 	e.workspacePath = workspacePath
 }
 
-func (e *Executor) Start(f def.Formula) def.Job {
+func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
-	job := basicjob.New()
+	job := basicjob.New(id)
 
 	go func() {
 		// Run the formula in a temporary directory

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -1,7 +1,6 @@
 package chroot
 
 import (
-	. "fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -92,7 +91,6 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string) def.JobResult {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	Println("Running formula...")
 	if err := cmd.Start(); err != nil {
 		if err2, ok := err.(*exec.Error); ok && err2.Err == exec.ErrNotFound {
 			panic(executor.NoSuchCommandError.Wrap(err))

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/input"
 	"polydawn.net/repeatr/input/fixtures"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/testutil"
 )
 
@@ -37,7 +38,7 @@ func Test(t *testing.T) {
 			So(os.Mkdir(e.workspacePath, 0755), ShouldBeNil)
 
 			Convey("We should get an InputError", func() {
-				result := e.Start(formula).Wait()
+				result := e.Start(formula, def.JobID(guid.New())).Wait()
 				So(result.Error, testutil.ShouldBeErrorClass, input.Error)
 			})
 		}),
@@ -67,7 +68,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"echo", "echococo"},
 				}
 
-				job := e.Start(formula)
+				job := e.Start(formula, def.JobID(guid.New()))
 				So(job, ShouldNotBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 0) // TODO: this waits... the test should still pass if the reader happens first
 			})
@@ -77,7 +78,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"sh", "-c", "exit 14"},
 				}
 
-				job := e.Start(formula)
+				job := e.Start(formula, def.JobID(guid.New()))
 				So(job, ShouldNotBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 14)
 			})
@@ -87,7 +88,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"not a command"},
 				}
 
-				result := e.Start(formula).Wait()
+				result := e.Start(formula, def.JobID(guid.New())).Wait()
 				So(result.Error, testutil.ShouldBeErrorClass, executor.NoSuchCommandError)
 			})
 
@@ -100,7 +101,7 @@ func Test(t *testing.T) {
 						Entrypoint: []string{"ls", "/data/test"},
 					}
 
-					job := e.Start(formula)
+					job := e.Start(formula, def.JobID(guid.New()))
 					So(job, ShouldNotBeNil)
 					So(job.Wait().ExitCode, ShouldEqual, 0)
 				})

--- a/executor/dispatch/dispatch.go
+++ b/executor/dispatch/dispatch.go
@@ -15,7 +15,7 @@ import (
 // Should attempt to reflect-find, trying main package name first.
 // Will make simpler to use extended transports, etc.
 
-func Get(desire string) *executor.Executor {
+func Get(desire string) executor.Executor {
 	var executor executor.Executor
 
 	switch desire {
@@ -32,5 +32,5 @@ func Get(desire string) *executor.Executor {
 	// Set the base path to operate from
 	executor.Configure(filepath.Join(os.TempDir(), "repeatr", "executor", desire))
 
-	return &executor
+	return executor
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -27,7 +27,7 @@ type Executor interface {
 		It is assumed that any job-specific filesystem state will be cleaned up by the executor.
 
 	*/
-	Start(def.Formula) def.Job
+	Start(def.Formula, def.JobID) def.Job
 
 	/*
 		ADDITIONALLY, we have some patterns that are merely conventions:

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -4,7 +4,16 @@ import (
 	"polydawn.net/repeatr/def"
 )
 
+/*
+	In general, executors are assumed to be running on the host that will run the Forumla.
+
+	Coordinating remote hosts is generally the responsibiltiy of a scheduler.
+*/
 type Executor interface {
+
+	/*
+		Prepare the Executor with information it needs to run.
+	*/
 	Configure(workspacePath string)
 
 	/*

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -27,10 +27,10 @@ func (e *Executor) Configure(workspacePath string) {
 	e.workspacePath = workspacePath
 }
 
-func (e *Executor) Start(f def.Formula) def.Job {
+func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
-	job := basicjob.New()
+	job := basicjob.New(id)
 
 	go func() {
 		// Run the formula in a temporary directory

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -1,7 +1,6 @@
 package nsinit
 
 import (
-	. "fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -117,7 +116,6 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string) def.JobResult {
 	flak.ProvisionInputs(f.Inputs, rootfs)
 	flak.ProvisionOutputs(f.Outputs, rootfs)
 
-	Println("Running formula...")
 	err := cmd.Run()
 	if err != nil {
 		panic(err)

--- a/executor/null/null_executor.go
+++ b/executor/null/null_executor.go
@@ -2,8 +2,12 @@ package null
 
 import (
 	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/executor/basicjob"
 )
+
+// interface assertion
+var _ executor.Executor = &Executor{}
 
 type Executor struct {
 }
@@ -11,8 +15,8 @@ type Executor struct {
 func (*Executor) Configure(workspacePath string) {
 }
 
-func (*Executor) Start(f def.Formula) def.Job {
-	job := basicjob.New()
+func (*Executor) Start(f def.Formula, id def.JobID) def.Job {
+	job := basicjob.New(id)
 
 	go func() {
 		close(job.WaitChan)

--- a/scheduler/dispatch/dispatch.go
+++ b/scheduler/dispatch/dispatch.go
@@ -3,18 +3,21 @@ package schedulerdispatch
 import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/scheduler"
+	"polydawn.net/repeatr/scheduler/group"
 	"polydawn.net/repeatr/scheduler/linear"
 )
 
-func Get(desire string) *scheduler.Scheduler {
+func Get(desire string) scheduler.Scheduler {
 	var scheduler scheduler.Scheduler
 
 	switch desire {
+	case "group":
+		scheduler = &group.Scheduler{}
 	case "linear":
 		scheduler = &linear.Scheduler{}
 	default:
 		panic(def.ValidationError.New("No such scheduler %s", desire))
 	}
 
-	return &scheduler
+	return scheduler
 }

--- a/scheduler/dispatch/dispatch.go
+++ b/scheduler/dispatch/dispatch.go
@@ -1,0 +1,20 @@
+package schedulerdispatch
+
+import (
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/scheduler"
+	"polydawn.net/repeatr/scheduler/linear"
+)
+
+func Get(desire string) *scheduler.Scheduler {
+	var scheduler scheduler.Scheduler
+
+	switch desire {
+	case "linear":
+		scheduler = &linear.Scheduler{}
+	default:
+		panic(def.ValidationError.New("No such scheduler %s", desire))
+	}
+
+	return &scheduler
+}

--- a/scheduler/errors.go
+++ b/scheduler/errors.go
@@ -1,0 +1,11 @@
+package scheduler
+
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
+// grouping, do not instantiate
+var Error *errors.ErrorClass = errors.NewClass("SchedulerError")
+
+// error when a scheduler's queue was full and could not enqueue a forumla.
+var QueueFullError *errors.ErrorClass = Error.NewClass("QueueFullError")

--- a/scheduler/group/group.go
+++ b/scheduler/group/group.go
@@ -21,11 +21,11 @@ type hold struct {
 
 type Scheduler struct {
 	groupSize int
-	executor  *executor.Executor
+	executor  executor.Executor
 	queue     chan *hold
 }
 
-func (s *Scheduler) Configure(e *executor.Executor) {
+func (s *Scheduler) Configure(e executor.Executor) {
 	s.groupSize = runtime.NumCPU()
 	s.executor = e
 	s.queue = make(chan *hold)
@@ -57,7 +57,7 @@ func (s *Scheduler) Schedule(f def.Formula) (def.JobID, <-chan def.Job) {
 func (s *Scheduler) Run() {
 	for h := range s.queue {
 
-		job := (*s.executor).Start(h.forumla, h.id)
+		job := s.executor.Start(h.forumla, h.id)
 		h.response <- job
 		job.Wait()
 	}

--- a/scheduler/group/group.go
+++ b/scheduler/group/group.go
@@ -1,6 +1,8 @@
-package linear
+package group
 
 import (
+	"runtime"
+
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/scheduler"
@@ -16,17 +18,21 @@ type hold struct {
 }
 
 type Scheduler struct {
-	executor *executor.Executor
-	queue    chan *hold
+	groupSize int
+	executor  *executor.Executor
+	queue     chan *hold
 }
 
 func (s *Scheduler) Configure(e *executor.Executor) {
+	s.groupSize = runtime.NumCPU()
 	s.executor = e
 	s.queue = make(chan *hold)
 }
 
 func (s *Scheduler) Start() {
-	go s.Run()
+	for w := 1; w <= s.groupSize; w++ {
+		go s.Run()
+	}
 }
 
 func (s *Scheduler) Schedule(f def.Formula) <-chan def.Job {

--- a/scheduler/group/group.go
+++ b/scheduler/group/group.go
@@ -5,6 +5,7 @@ import (
 
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/scheduler"
 )
 
@@ -52,7 +53,8 @@ func (s *Scheduler) Schedule(f def.Formula) <-chan def.Job {
 // Run jobs one at a time
 func (s *Scheduler) Run() {
 	for h := range s.queue {
-		job := (*s.executor).Start(h.forumla)
+		id := def.JobID(guid.New())
+		job := (*s.executor).Start(h.forumla, id)
 		h.response <- job
 		job.Wait()
 	}

--- a/scheduler/linear/linear.go
+++ b/scheduler/linear/linear.go
@@ -22,9 +22,9 @@ type Scheduler struct {
 	queue    chan *hold
 }
 
-func (s *Scheduler) Configure(e executor.Executor) {
+func (s *Scheduler) Configure(e executor.Executor, queueSize int) {
 	s.executor = e
-	s.queue = make(chan *hold)
+	s.queue = make(chan *hold, queueSize)
 }
 
 func (s *Scheduler) Start() {
@@ -40,9 +40,12 @@ func (s *Scheduler) Schedule(f def.Formula) (def.JobID, <-chan def.Job) {
 		response: make(chan def.Job),
 	}
 
-	go func() {
-		s.queue <- h
-	}()
+	// Non-blocking send, will panic if scheduler queue is full
+	select {
+	case s.queue <- h:
+	default:
+		panic(scheduler.QueueFullError)
+	}
 
 	return id, h.response
 }

--- a/scheduler/linear/linear.go
+++ b/scheduler/linear/linear.go
@@ -1,0 +1,43 @@
+package linear
+
+import (
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/scheduler"
+)
+
+// interface assertion
+var _ scheduler.Scheduler = &Scheduler{}
+
+type Scheduler struct {
+	executor *executor.Executor
+	queue    chan def.Formula
+	results  chan def.Job
+}
+
+func (s *Scheduler) Configure(e *executor.Executor) {
+	s.executor = e
+	s.queue = make(chan def.Formula)
+	s.results = make(chan def.Job)
+}
+
+func (s *Scheduler) Start() {
+	go s.Run()
+}
+
+func (s *Scheduler) Queue() chan<- def.Formula {
+	return s.queue
+}
+
+func (s *Scheduler) Results() <-chan def.Job {
+	return s.results
+}
+
+// Run jobs one at a time
+func (s *Scheduler) Run() {
+	for f := range s.queue {
+		job := (*s.executor).Start(f)
+		s.results <- job
+		job.Wait()
+	}
+}

--- a/scheduler/linear/linear.go
+++ b/scheduler/linear/linear.go
@@ -3,6 +3,7 @@ package linear
 import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/scheduler"
 )
 
@@ -46,7 +47,8 @@ func (s *Scheduler) Schedule(f def.Formula) <-chan def.Job {
 // Run jobs one at a time
 func (s *Scheduler) Run() {
 	for h := range s.queue {
-		job := (*s.executor).Start(h.forumla)
+		id := def.JobID(guid.New())
+		job := (*s.executor).Start(h.forumla, id)
 		h.response <- job
 		job.Wait()
 	}

--- a/scheduler/linear/linear.go
+++ b/scheduler/linear/linear.go
@@ -18,11 +18,11 @@ type hold struct {
 }
 
 type Scheduler struct {
-	executor *executor.Executor
+	executor executor.Executor
 	queue    chan *hold
 }
 
-func (s *Scheduler) Configure(e *executor.Executor) {
+func (s *Scheduler) Configure(e executor.Executor) {
 	s.executor = e
 	s.queue = make(chan *hold)
 }
@@ -51,7 +51,7 @@ func (s *Scheduler) Schedule(f def.Formula) (def.JobID, <-chan def.Job) {
 func (s *Scheduler) Run() {
 	for h := range s.queue {
 
-		job := (*s.executor).Start(h.forumla, h.id)
+		job := s.executor.Start(h.forumla, h.id)
 		h.response <- job
 		job.Wait()
 	}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -19,11 +19,6 @@ import (
 
 	REVIEW: our interfaces do not support returning a guid from scheduling, as executors create their guid when starting.
 	It would be cleaner to be able to refer to a scheduled Job without waiting arbitrarily long for the scheduler to start the job.
-
-	PROPOSAL: executors lose control of guid generation, are are instead handed a guid.
-
-		Currently: Start(def.Formula)            def.Job
-		Proposed:  Start(def.Formula, def.JobID) def.Job
 */
 type Scheduler interface {
 

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -45,7 +45,6 @@ type Scheduler interface {
 		Schedules a Forumla to be ran, and returns a channel that will hand you a Job.
 	*/
 	Schedule(def.Formula) <-chan def.Job
-
 }
 
 /*

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -25,7 +25,7 @@ type Scheduler interface {
 		It is guaranteed that calling Use() before scheduling work will behave as expected.
 		Calling Use() after scheduling work is left for the Scheduler to decide - it might change, panic, ignore, etc.
 	*/
-	Configure(*executor.Executor)
+	Configure(executor.Executor)
 
 	/*
 		Start consuming Formulas.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -25,7 +25,7 @@ type Scheduler interface {
 		It is guaranteed that calling Use() before scheduling work will behave as expected.
 		Calling Use() after scheduling work is left for the Scheduler to decide - it might change, panic, ignore, etc.
 	*/
-	Configure(executor.Executor)
+	Configure(e executor.Executor, queueSize int)
 
 	/*
 		Start consuming Formulas.

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -16,9 +16,6 @@ import (
 
 	Schedulers are presumed to know environmental context that a Formula provider may not.
 	Any problems with a transport running on a remote host, for example, is the scheduler's problem.
-
-	REVIEW: our interfaces do not support returning a guid from scheduling, as executors create their guid when starting.
-	It would be cleaner to be able to refer to a scheduled Job without waiting arbitrarily long for the scheduler to start the job.
 */
 type Scheduler interface {
 
@@ -37,9 +34,9 @@ type Scheduler interface {
 	Start()
 
 	/*
-		Schedules a Forumla to be ran, and returns a channel that will hand you a Job.
+		Schedules a Forumla to run; returns the job ID and a channel that will hand you a Job instance.
 	*/
-	Schedule(def.Formula) <-chan def.Job
+	Schedule(def.Formula) (def.JobID, <-chan def.Job)
 }
 
 /*

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -36,32 +36,16 @@ type Scheduler interface {
 	Configure(*executor.Executor)
 
 	/*
-		Starts consuming formulas.
-		It is expected that you call Configure(), then Start(), before queuing formulas.
+		Start consuming Formulas.
+		It is expected that you call Configure(), then Start(), before scheduling Formulas.
 	*/
 	Start()
 
 	/*
-		REVIEW: thoughts on exposing channels here?
-		We could add or substitute a Schedule(def.Formula)
-
+		Schedules a Forumla to be ran, and returns a channel that will hand you a Job.
 	*/
+	Schedule(def.Formula) <-chan def.Job
 
-	/*
-		Returns a channel that you can send Formulas to.
-		These will be asynchronously scheduled to run.
-
-		Channel semantics (blocking or buffer) behavior is currently unspecified.
-	*/
-	Queue() chan<- def.Formula
-
-	/*
-		Returns a channel that you can read Jobs from.
-		These may be sent before the relevant Formula is actually started.
-
-		Channel semantics (blocking or buffer) behavior is currently unspecified.
-	*/
-	Results() <-chan def.Job
 }
 
 /*


### PR DESCRIPTION
Branch name is a slight misnomer, as two schedulers landed.

* Added some docs to Executor interface methods.
* Designed a nascent Scheduler interface
* Landed a linear scheduler. Runs one job at a time.
* Landed a group scheduler. Runs N jobs at a time, defaulting to the number of virtual CPU.

The linear scheduler was originally intended as a most-basic example of how to write a scheduler. Previous comments to the effect of "why not just use group with N=1" are not wrong; I would like to keep linear around regardless to ensure we always have a dead-simple reference. And, well, >1 implementations of an interface is better than one. Open to disagreement.

At minimum, left to do:

* Executor interface proposal was agreed on, take action

I wanted to get this into PR status so we can catch anything else.