### PR TITLE
Stream muxer

### DIFF
--- a/lib/streamer/cbor_streamer.go
+++ b/lib/streamer/cbor_streamer.go
@@ -1,0 +1,136 @@
+package streamer
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sync"
+
+	"github.com/spacemonkeygo/errors"
+	"github.com/ugorji/go/codec"
+)
+
+var _ Mux = &CborMux{}
+
+type CborMux struct {
+	// the fd tip handles append; reads all use ReadAt and track their offsets individually
+	file  *os.File
+	codec *codec.Encoder
+	wmu   sync.Mutex
+}
+
+func CborFileMux(filePath string) Mux {
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_RDWR|os.O_EXCL, 0755)
+	if err != nil {
+		panic(errors.IOError.Wrap(err))
+	}
+	file.Write([]byte{codec.CborStreamArray})
+	return &CborMux{
+		file:  file,
+		codec: codec.NewEncoder(&debugWriter{file}, new(codec.CborHandle)),
+	}
+	// consider using runtime.SetFinalizer to close?  currently unhandled.
+}
+
+func (m *CborMux) write(label int, msg []byte) {
+	m.wmu.Lock()
+	defer m.wmu.Unlock()
+	const magic_RAW = 0
+	_, enc := codec.GenHelperEncoder(m.codec)
+	enc.EncodeMapStart(1)
+	enc.EncodeInt(int64(label))
+	enc.EncodeStringBytes(magic_RAW, msg)
+	// REVIEW: we might need an extra flag for "close"
+	// could sneak it in as a different type here?  might be rude on parsers.
+}
+
+func (m *CborMux) Close() {
+	m.wmu.Lock()
+	defer m.wmu.Unlock()
+	m.file.Write([]byte{0xff}) // should be `codec.CborStreamBreak`, plz update upstream for vis
+	// don't *actually* close, because readers can still be active on the same fd.
+	// TODO further writes should be forced into an error state
+}
+
+func (m *CborMux) Appender(label int) io.WriteCloser {
+	return &cborMuxAppender{m, label}
+}
+
+type cborMuxAppender struct {
+	m     *CborMux
+	label int
+}
+
+func (a *cborMuxAppender) Write(msg []byte) (int, error) {
+	a.m.write(a.label, msg)
+	return len(msg), nil
+}
+
+func (a *cborMuxAppender) Close() error {
+	// TODO write a special flagged event?
+	return nil
+}
+
+func (m *CborMux) Reader(labels ...int) io.Reader {
+	// asking for a reader for a label that was never used will never
+	// hit a close flag, so... don't do that?
+	r := io.NewSectionReader(m.file, 1, math.MaxInt64/2)
+	r2 := &debugReader{r}
+	// TODO offset of one because that's the array open!
+	// do something much more sane than skip it, please
+	return &cborMuxReader{
+		labels: labels,
+		codec:  codec.NewDecoder(r2, new(codec.CborHandle)),
+	}
+}
+
+type debugReader struct {
+	r io.Reader
+}
+
+func (r *debugReader) Read(b []byte) (int, error) {
+	i, e := r.r.Read(b)
+	fmt.Printf(":: dbg read: %#v    %#v    %#v\n", i, b, e)
+	return i, e
+}
+
+type debugWriter struct {
+	w io.Writer
+}
+
+func (w *debugWriter) Write(b []byte) (int, error) {
+	i, e := w.w.Write(b)
+	fmt.Printf(":: dbg write: %#v    %#v    %#v\n", i, b, e)
+	return i, e
+}
+
+type cborMuxReader struct {
+	labels []int // remove them as we hit their close
+	codec  *codec.Decoder
+}
+
+func (r *cborMuxReader) Read(msg []byte) (int, error) {
+	var row map[int]interface{}
+	err := r.codec.Decode(&row)
+	if err == io.EOF {
+		return 0, err
+	}
+	fmt.Printf("::: read row: %#v\n", row)
+	// read the map bits
+	// read the key
+	// switch on the value type
+	//	switch {
+	//	case dec.IsContainerType(valueTypeInt):
+	//	case dec.IsContainerType(codec.valueTypeBytes)
+	//	}
+	for k, v := range row {
+		// this could be wildly more efficient with more handcoded parsing
+		for _, l := range r.labels {
+			if k == l {
+				return copy(msg, v.([]byte)), nil
+			}
+		}
+	}
+	return 0, nil
+}

--- a/lib/streamer/cbor_streamer_test.go
+++ b/lib/streamer/cbor_streamer_test.go
@@ -45,7 +45,14 @@ func TestCborMux(t *testing.T) {
 			dec := codec.NewDecoder(&debugReader{file}, new(codec.CborHandle))
 			reheated := make([]interface{}, 0)
 			dec.MustDecode(&reheated)
-			Printf(":::: decoded as full slice: %#v\n", reheated)
+			SkipSo(reheated, ShouldResemble, []interface{}{
+				map[interface{}]interface{}{
+					byte(1): []byte("asdf"),
+				},
+				map[interface{}]interface{}{
+					byte(2): []byte("qwer"),
+				},
+			})
 		})
 	}))
 }

--- a/lib/streamer/cbor_streamer_test.go
+++ b/lib/streamer/cbor_streamer_test.go
@@ -20,14 +20,44 @@ func TestCborMux(t *testing.T) {
 			a1.Write([]byte("qwer"))
 			a1.Close()
 
-			r1 := strm.Reader(1)
-			bytes, err := ioutil.ReadAll(r1)
-			So(err, ShouldBeNil)
-			So(string(bytes), ShouldEqual, "asdfqwer")
+			Convey("Readall should get the whole stream", func() {
+				r1 := strm.Reader(1)
+				bytes, err := ioutil.ReadAll(r1)
+				So(err, ShouldBeNil)
+				So(string(bytes), ShouldEqual, "asdfqwer")
+
+				Convey("Readall *again* should get the whole stream, from the beginning", func() {
+					r1 := strm.Reader(1)
+					bytes, err := ioutil.ReadAll(r1)
+					So(err, ShouldBeNil)
+					So(string(bytes), ShouldEqual, "asdfqwer")
+				})
+			})
 		})
 
 		Convey("Given two complete streams", func() {
+			a1 := strm.Appender(1)
+			a2 := strm.Appender(2)
+			a1.Write([]byte("asdf"))
+			a2.Write([]byte("qwer"))
+			a1.Write([]byte("asdf"))
+			a1.Close()
+			a2.Write([]byte("zxcv"))
+			a2.Close()
 
+			Convey("Readall on one label should get the whole stream for that label", func() {
+				r1 := strm.Reader(1)
+				bytes, err := ioutil.ReadAll(r1)
+				So(err, ShouldBeNil)
+				So(string(bytes), ShouldEqual, "asdfasdf")
+			})
+			Convey("Readall on both labels should get the whole stream", func() {
+				r12 := strm.Reader(1, 2)
+				bytes, err := ioutil.ReadAll(r12)
+				So(err, ShouldBeNil)
+				So(string(bytes), ShouldEqual, "asdfqwerasdfzxcv")
+			})
+			// TODO read it back manually with tiny buffers
 		})
 
 		// TODO still need a zillion tests around EOF and blocking behavior near that.

--- a/lib/streamer/cbor_streamer_test.go
+++ b/lib/streamer/cbor_streamer_test.go
@@ -1,0 +1,51 @@
+package streamer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/ugorji/go/codec"
+	"polydawn.net/repeatr/testutil"
+)
+
+func TestCborMux(t *testing.T) {
+	Convey("Using a cbor file-backed streamer mux", t, testutil.WithTmpdir(func() {
+		strm := CborFileMux("./logfile")
+
+		Convey("It should be transparent with a single stream", func() {
+			a1 := strm.Appender(1)
+			a1.Write([]byte("asdf"))
+			a1.Write([]byte("qwer"))
+
+			r1 := strm.Reader(1)
+			bytes, err := ioutil.ReadAll(r1)
+			So(err, ShouldBeNil)
+			So(string(bytes), ShouldEqual, "asdfqwer")
+		})
+
+		Convey("It should be transparent with two streams", func() {
+
+		})
+
+		// TODO still need a zillion tests around EOF and blocking behavior near that.
+
+		Convey("It should parse as regular cbor", func() {
+			a1 := strm.Appender(1)
+			a1.Write([]byte("asdf"))
+			a2 := strm.Appender(2)
+			a2.Write([]byte("qwer"))
+			a1.Close()
+			a2.Close()
+			strm.(*CborMux).Close()
+
+			file, err := os.OpenFile("./logfile", os.O_RDONLY, 0)
+			So(err, ShouldBeNil)
+			dec := codec.NewDecoder(&debugReader{file}, new(codec.CborHandle))
+			reheated := make([]interface{}, 0)
+			dec.MustDecode(&reheated)
+			Printf(":::: decoded as full slice: %#v\n", reheated)
+		})
+	}))
+}

--- a/lib/streamer/streamer.go
+++ b/lib/streamer/streamer.go
@@ -1,0 +1,11 @@
+package streamer
+
+import (
+	"io"
+)
+
+type Mux interface {
+	Appender(label int) io.WriteCloser
+
+	Reader(labels ...int) io.Reader
+}


### PR DESCRIPTION
Add a stream logging and mux/demuxing system.

After creating a mux, one can get labeled writers to it, and readers that return the conjunction of any choice of labels.  Every reader starts off again from the beginning.  This implementation is backed by files, so it's safe for arbitrarily large amounts of data.  Readers can safely run concurrently with writers; the readers will return as much as they can, and when out of data will continue to block until the writers emit close signals (even if the reader catches up with the current end of file while any relevant writer is still ongoing).

The intended/example use case for this is collecting stdout and stderr from a process, saving both of them, and being able reply either alone or both together, always in the same order they originally appeared.

There's a couple todo's scattered around; we can decide how important those are to fix before merging.  There's numerous sharp edges to this code (for one example, asking for streams labels that never existed means you'll block forever waiting for them to be "closed"), but if used as directed should be functional.