### PR TITLE
Exec upgrades

### DIFF
--- a/input/errors.go
+++ b/input/errors.go
@@ -1,0 +1,30 @@
+package input
+
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
+var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
+
+/*
+	Indicates that the input failed to obtain data that correctly
+	matches the hash specifying the input.  This may mean there have
+	been data integrity issues in the storage or transport systems involved.
+*/
+var InputHashMismatchError *errors.ErrorClass = Error.NewClass("InputHashMismatchError")
+
+/*
+	Indicates that the target filesystem (the one given to `Apply`) had some error.
+*/
+var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("TargetFilesystemUnavailableError")
+
+// Convenience method for wrapping io errors.
+func TargetFilesystemUnavailableIOError(err error) *errors.Error {
+	return TargetFilesystemUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
+}
+
+/*
+	Wraps any other unknown errors just to emphasize the system that raised them;
+	any well known errors should use a different type.
+*/
+var UnknownError *errors.ErrorClass = Error.NewClass("InputUnknownError")

--- a/input/input.go
+++ b/input/input.go
@@ -1,9 +1,5 @@
 package input
 
-import (
-	"github.com/spacemonkeygo/errors"
-)
-
 type Input interface {
 	/*
 		Set the contents of the given filesystem path to the contents
@@ -31,7 +27,3 @@ type Input interface {
 	*/
 	Apply(path string) <-chan error
 }
-
-var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
-
-var InputHashMismatchError *errors.ErrorClass = Error.NewClass("InputHashMismatchError")


### PR DESCRIPTION
Start upgrading use of exec to use [Gosh](https://github.com/polydawn/gosh/).

Using gosh means their error handling is now consistent in all the ways gosh addresses (exit codes are accounted for, signals are accounted for, ptrace is accounted for, etc; we can remove that copyforked stuff from repeatr).   In the cases upgraded here, we also now make operations silently (not mucking up the host terminal), and if something goes wrong then (and only then) attach output to the error we're about to raise -- this fixes a few places where goconvey was reporting fails because of misdirected output.
