### PR TITLE
Use mux in executors

### DIFF
--- a/cli/run.go
+++ b/cli/run.go
@@ -55,7 +55,7 @@ func RunFormulae(s scheduler.Scheduler, e executor.Executor, f ...def.Formula) {
 			result := job.Wait()
 
 			if result.Error != nil {
-				Println("Job", n, id, "had an executor error:", result.Error)
+				Println("Job", n, id, "failed with", result.Error.Message())
 			} else {
 				Println("Job", n, id, "finished with code", result.ExitCode, "and outputs", result.Outputs)
 			}

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -29,29 +29,45 @@ func (e *Executor) Configure(workspacePath string) {
 }
 
 func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
+
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
+
 	job := basicjob.New(id)
+	jobReady := make(chan struct{})
 
 	go func() {
 		// Run the formula in a temporary directory
 		flak.WithDir(func(dir string) {
-			job.Result = e.Run(f, job, dir)
+
+			// spool our output to a muxed stream
+			var strm streamer.Mux
+			strm = streamer.CborFileMux(filepath.Join(dir, "log"))
+
+			outS := strm.Appender(1)
+			errS := strm.Appender(2)
+			job.Reader = strm.Reader(1, 2)
+
+			// Job is ready to stream process output
+			close(jobReady)
+
+			job.Result = e.Run(f, job, dir, outS, errS)
 		}, e.workspacePath, "job", string(job.Id()))
 
 		// Directory is clean; job complete
 		close(job.WaitChan)
 	}()
 
-	return def.Job(job)
+	<-jobReady
+	return job
 }
 
 // Executes a job, catching any panics.
-func (e *Executor) Run(f def.Formula, j def.Job, d string) def.JobResult {
+func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
 	var r def.JobResult
 
 	try.Do(func() {
-		r = e.Execute(f, j, d)
+		r = e.Execute(f, j, d, outS, errS)
 	}).Catch(executor.Error, func(err *errors.Error) {
 		r.Error = err
 	}).Catch(input.Error, func(err *errors.Error) {
@@ -66,7 +82,7 @@ func (e *Executor) Run(f def.Formula, j def.Job, d string) def.JobResult {
 }
 
 // Execute a formula in a specified directory. MAY PANIC.
-func (e *Executor) Execute(f def.Formula, j def.Job, d string) def.JobResult {
+func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
 
 	result := def.JobResult{
 		ID:       j.Id(),
@@ -110,13 +126,9 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string) def.JobResult {
 	// Prepare command to exec
 	cmd := exec.Command("nsinit", args...)
 
-	// spool our output to a muxed stream
-	var strm streamer.Mux
-	strm = streamer.CborFileMux(filepath.Join(d, "log"))
 	cmd.Stdin = nil
-	cmd.Stdout = strm.Appender(1)
-	cmd.Stderr = strm.Appender(2)
-	j.(*basicjob.BasicJob).Reader = strm.Reader(1, 2)
+	cmd.Stdout = outS
+	cmd.Stderr = errS
 	defer func() {
 		// Close output streams.
 		// (I thought exec should do this already...?  But doesn't seem to.)

--- a/lib/flak/provision.go
+++ b/lib/flak/provision.go
@@ -28,7 +28,6 @@ func ProvisionInputs(inputs []def.Input, rootfs string) {
 		// Run input
 		err = <-inputdispatch.Get(input).Apply(path)
 		if err != nil {
-			Println("Input", x+1, "failed:", err)
 			panic(err)
 		}
 	}
@@ -55,7 +54,6 @@ func PreserveOutputs(outputs []def.Output, rootfs string) []def.Output {
 
 		report := <-outputdispatch.Get(output).Apply(rootfs)
 		if report.Err != nil {
-			Println("Output", x+1, "failed:", report.Err)
 			panic(report.Err)
 		}
 		Println("Output", x+1, "hash:", report.Output.Hash)

--- a/lib/integration/basic.json
+++ b/lib/integration/basic.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"Accents": {
-		"Entrypoint": [ "echo", "Hello from repeatr!" ]
+		"Entrypoint": [ "bash", "-c", "echo hello1; sleep .5; echo hello2; sleep .5; echo hello3" ]
 	},
 	"Outputs": [
 		{


### PR DESCRIPTION
* Hooks up the new stream mux to executors.
* Delays handing off the Job until the muxes are ready.
 * Does nothing to improve the Job situation; that's a different topic
* Now that we have nicer error handling, squelch redundant reporting
* Stream job output from mux to CLI in real time