### PR TITLE
Universal output redirection, more exit handling

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,16 +2,15 @@ package cli
 
 import (
 	"github.com/codegangsta/cli"
+	"io"
 
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor/dispatch"
 	"polydawn.net/repeatr/scheduler/dispatch"
 )
 
-var App *cli.App
-
-func init() {
-	App = cli.NewApp()
+func Main(args []string, journal io.Writer) {
+	App := cli.NewApp()
 
 	App.Name = "repeatr"
 	App.Usage = "Run it. Run it again."
@@ -23,7 +22,7 @@ func init() {
 		{
 			Name:   "run",
 			Usage:  "Run a formula",
-			Action: Run,
+			Action: func(c *cli.Context) { Run(c, journal) },
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "executor, e",
@@ -43,9 +42,11 @@ func init() {
 			},
 		},
 	}
+
+	App.Run(args)
 }
 
-func Run(c *cli.Context) {
+func Run(c *cli.Context, journal io.Writer) {
 	executor := executordispatch.Get(c.String("executor"))
 	scheduler := schedulerdispatch.Get(c.String("scheduler"))
 	paths := c.StringSlice("input")
@@ -55,5 +56,5 @@ func Run(c *cli.Context) {
 		formulae = append(formulae, LoadFormulaFromFile(path))
 	}
 
-	RunFormulae(scheduler, executor, formulae...)
+	RunFormulae(scheduler, executor, journal, formulae...)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -16,6 +16,8 @@ func Main(args []string, journal io.Writer) {
 	App.Usage = "Run it. Run it again."
 	App.Version = "0.0.1"
 
+	App.Writer = journal
+
 	bat := cli.StringSlice([]string{})
 
 	App.Commands = []cli.Command{

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -25,12 +26,12 @@ func Test(t *testing.T) {
 	}
 
 	Convey("It should not crash without args", t, func() {
-		App.Run(baseArgs)
+		Main(baseArgs, ioutil.Discard)
 	})
 
 	testutil.Convey_IfCanNS("Within an environment that can run namespaces", t, func() {
 		testutil.Convey_IfHaveRoot("It should run a basic example", func() {
-			App.Run(append(baseArgs, "run", "-i", "lib/integration/basic.json"))
+			Main(append(baseArgs, "run", "-i", "lib/integration/basic.json"), ioutil.Discard)
 		})
 	})
 

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"github.com/spacemonkeygo/errors"
+)
+
+type ExitCode byte
+
+const (
+	EXIT_BADARGS      = ExitCode(1)
+	EXIT_UNKNOWNPANIC = ExitCode(2) // same code as golang uses when the process dies naturally on an unhandled panic.
+	EXIT_USER         = ExitCode(3) // grab bag for general user input errors (try to make a more specific code if possible/useful)
+)
+
+/*
+	CLI errors are the last line: they should be formatted to be user-facing.
+	The main method will convert a CLIError into a short and well-formatted
+	message, and will *not* include stack traces unless the user is running
+	with debug mode enabled.
+
+	CLI errors are an appropriate wrapping for anything where we can map a
+	problem onto something the user can understand and fix.  Errors that are
+	a repeatr bug or unknown territory should *not* be mapped into a CLIError.
+*/
+var Error *errors.ErrorClass = errors.NewClass("CLIError")

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -12,6 +12,8 @@ const (
 	EXIT_USER         = ExitCode(3) // grab bag for general user input errors (try to make a more specific code if possible/useful)
 )
 
+var ExitCodeKey = errors.GenSym()
+
 /*
 	CLI errors are the last line: they should be formatted to be user-facing.
 	The main method will convert a CLIError into a short and well-formatted
@@ -23,3 +25,13 @@ const (
 	a repeatr bug or unknown territory should *not* be mapped into a CLIError.
 */
 var Error *errors.ErrorClass = errors.NewClass("CLIError")
+
+/*
+	Use this to set a specific error code the process should exit with
+	when producing a `cli.Error`.
+
+	Example: `cli.Error.New("something terrible!", SetExitCode(EXIT_BADARGS))`
+*/
+func SetExitCode(code ExitCode) errors.ErrorOption {
+	return errors.SetData(ExitCodeKey, code)
+}

--- a/cli/run.go
+++ b/cli/run.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sync"
 
@@ -54,7 +53,7 @@ func RunFormulae(s scheduler.Scheduler, e executor.Executor, journal io.Writer, 
 
 			// Stream job output to terminal in real time
 			// TODO: This ruins stdout / stderr split. Job should probably just expose the Mux interface.
-			_, err := io.Copy(os.Stdout, job.OutputReader())
+			_, err := io.Copy(journal, job.OutputReader())
 			if err != nil {
 				// TODO: This is serious, how to handle in CLI context debatable
 				fmt.Fprintln(journal, "Error reading job stream")

--- a/cli/run.go
+++ b/cli/run.go
@@ -20,9 +20,7 @@ func LoadFormulaFromFile(path string) def.Formula {
 
 	content, err := ioutil.ReadFile(filename)
 	if err != nil {
-		Println(err)
-		Println("Could not read file", filename)
-		os.Exit(1)
+		panic(Error.Wrap(Errorf("Could not read formula file %q: %s", filename, err)))
 	}
 
 	dec := codec.NewDecoderBytes(content, &codec.JsonHandle{})

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -12,6 +12,7 @@ import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/executor/basicjob"
+	"polydawn.net/repeatr/executor/util"
 	"polydawn.net/repeatr/input"
 	"polydawn.net/repeatr/lib/flak"
 	"polydawn.net/repeatr/lib/streamer"
@@ -91,8 +92,8 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 
 	// Prepare filesystem
 	rootfs := filepath.Join(d, "rootfs")
-	flak.ProvisionInputs(f.Inputs, rootfs)
-	flak.ProvisionOutputs(f.Outputs, rootfs)
+	util.ProvisionInputs(f.Inputs, rootfs)
+	util.ProvisionOutputs(f.Outputs, rootfs)
 
 	// chroot's are pretty easy.
 	cmdName := f.Accents.Entrypoint[0]
@@ -136,7 +137,7 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	result.ExitCode = proc.GetExitCode()
 
 	// Save outputs
-	result.Outputs = flak.PreserveOutputs(f.Outputs, rootfs)
+	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs)
 
 	return result
 }

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -29,7 +29,7 @@ func (e *Executor) Configure(workspacePath string) {
 	e.workspacePath = workspacePath
 }
 
-func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
+func (e *Executor) Start(f def.Formula, id def.JobID, journal io.Writer) def.Job {
 
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
@@ -52,7 +52,7 @@ func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 			// Job is ready to stream process output
 			close(jobReady)
 
-			job.Result = e.Run(f, job, dir, outS, errS)
+			job.Result = e.Run(f, job, dir, outS, errS, journal)
 		}, e.workspacePath, "job", string(job.Id()))
 
 		// Directory is clean; job complete
@@ -64,11 +64,11 @@ func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 }
 
 // Executes a job, catching any panics.
-func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
+func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
 	var r def.JobResult
 
 	try.Do(func() {
-		r = e.Execute(f, j, d, outS, errS)
+		r = e.Execute(f, j, d, outS, errS, journal)
 	}).Catch(executor.Error, func(err *errors.Error) {
 		r.Error = err
 	}).Catch(input.Error, func(err *errors.Error) {
@@ -83,7 +83,7 @@ func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCl
 }
 
 // Execute a formula in a specified directory. MAY PANIC.
-func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
+func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
 
 	result := def.JobResult{
 		ID:      j.Id(),
@@ -92,8 +92,8 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 
 	// Prepare filesystem
 	rootfs := filepath.Join(d, "rootfs")
-	util.ProvisionInputs(f.Inputs, rootfs)
-	util.ProvisionOutputs(f.Outputs, rootfs)
+	util.ProvisionInputs(f.Inputs, rootfs, journal)
+	util.ProvisionOutputs(f.Outputs, rootfs, journal)
 
 	// chroot's are pretty easy.
 	cmdName := f.Accents.Entrypoint[0]
@@ -137,7 +137,7 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	result.ExitCode = proc.GetExitCode()
 
 	// Save outputs
-	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs)
+	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs, journal)
 
 	return result
 }

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -39,7 +39,7 @@ func Test(t *testing.T) {
 			So(os.Mkdir(e.workspacePath, 0755), ShouldBeNil)
 
 			Convey("We should get an InputError", func() {
-				result := e.Start(formula, def.JobID(guid.New())).Wait()
+				result := e.Start(formula, def.JobID(guid.New()), ioutil.Discard).Wait()
 				So(result.Error, testutil.ShouldBeErrorClass, input.Error)
 			})
 		}),
@@ -69,7 +69,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"echo", "echococo"},
 				}
 
-				job := e.Start(formula, def.JobID(guid.New()))
+				job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
 				So(job, ShouldNotBeNil)
 				// note that we can read output concurrently.
 				// no need to wait for job done.
@@ -85,7 +85,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"sh", "-c", "exit 14"},
 				}
 
-				job := e.Start(formula, def.JobID(guid.New()))
+				job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
 				So(job, ShouldNotBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 14)
 			})
@@ -95,7 +95,7 @@ func Test(t *testing.T) {
 					Entrypoint: []string{"not a command"},
 				}
 
-				result := e.Start(formula, def.JobID(guid.New())).Wait()
+				result := e.Start(formula, def.JobID(guid.New()), ioutil.Discard).Wait()
 				So(result.Error, testutil.ShouldBeErrorClass, executor.NoSuchCommandError)
 			})
 
@@ -108,7 +108,7 @@ func Test(t *testing.T) {
 						Entrypoint: []string{"ls", "/data/test"},
 					}
 
-					job := e.Start(formula, def.JobID(guid.New()))
+					job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
 					So(job, ShouldNotBeNil)
 					So(job.Wait().ExitCode, ShouldEqual, 0)
 					msg, err := ioutil.ReadAll(job.OutputReader())

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"io"
+
 	"polydawn.net/repeatr/def"
 )
 
@@ -27,7 +29,7 @@ type Executor interface {
 		It is assumed that any job-specific filesystem state will be cleaned up by the executor.
 
 	*/
-	Start(def.Formula, def.JobID) def.Job
+	Start(def.Formula, def.JobID, io.Writer) def.Job
 
 	/*
 		ADDITIONALLY, we have some patterns that are merely conventions:

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -11,6 +11,7 @@ import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/executor/basicjob"
+	"polydawn.net/repeatr/executor/util"
 	"polydawn.net/repeatr/input"
 	"polydawn.net/repeatr/lib/flak"
 	"polydawn.net/repeatr/lib/streamer"
@@ -137,8 +138,8 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	}()
 
 	// Prepare filesystem
-	flak.ProvisionInputs(f.Inputs, rootfs)
-	flak.ProvisionOutputs(f.Outputs, rootfs)
+	util.ProvisionInputs(f.Inputs, rootfs)
+	util.ProvisionOutputs(f.Outputs, rootfs)
 
 	err := cmd.Run()
 	if err != nil {
@@ -146,6 +147,6 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	}
 
 	// Save outputs
-	result.Outputs = flak.PreserveOutputs(f.Outputs, rootfs)
+	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs)
 	return result
 }

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -29,7 +29,7 @@ func (e *Executor) Configure(workspacePath string) {
 	e.workspacePath = workspacePath
 }
 
-func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
+func (e *Executor) Start(f def.Formula, id def.JobID, journal io.Writer) def.Job {
 
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
@@ -52,7 +52,7 @@ func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 			// Job is ready to stream process output
 			close(jobReady)
 
-			job.Result = e.Run(f, job, dir, outS, errS)
+			job.Result = e.Run(f, job, dir, outS, errS, journal)
 		}, e.workspacePath, "job", string(job.Id()))
 
 		// Directory is clean; job complete
@@ -64,11 +64,11 @@ func (e *Executor) Start(f def.Formula, id def.JobID) def.Job {
 }
 
 // Executes a job, catching any panics.
-func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
+func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
 	var r def.JobResult
 
 	try.Do(func() {
-		r = e.Execute(f, j, d, outS, errS)
+		r = e.Execute(f, j, d, outS, errS, journal)
 	}).Catch(executor.Error, func(err *errors.Error) {
 		r.Error = err
 	}).Catch(input.Error, func(err *errors.Error) {
@@ -83,7 +83,7 @@ func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCl
 }
 
 // Execute a formula in a specified directory. MAY PANIC.
-func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser) def.JobResult {
+func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
 
 	result := def.JobResult{
 		ID:       j.Id(),
@@ -138,8 +138,8 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	}()
 
 	// Prepare filesystem
-	util.ProvisionInputs(f.Inputs, rootfs)
-	util.ProvisionOutputs(f.Outputs, rootfs)
+	util.ProvisionInputs(f.Inputs, rootfs, journal)
+	util.ProvisionOutputs(f.Outputs, rootfs, journal)
 
 	err := cmd.Run()
 	if err != nil {
@@ -147,6 +147,6 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	}
 
 	// Save outputs
-	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs)
+	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs, journal)
 	return result
 }

--- a/executor/null/null_executor.go
+++ b/executor/null/null_executor.go
@@ -1,6 +1,8 @@
 package null
 
 import (
+	"io"
+
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/executor/basicjob"
@@ -15,7 +17,7 @@ type Executor struct {
 func (*Executor) Configure(workspacePath string) {
 }
 
-func (*Executor) Start(f def.Formula, id def.JobID) def.Job {
+func (*Executor) Start(f def.Formula, id def.JobID, journal io.Writer) def.Job {
 	job := basicjob.New(id)
 
 	go func() {

--- a/executor/util/provision.go
+++ b/executor/util/provision.go
@@ -1,4 +1,4 @@
-package flak
+package util
 
 import (
 	. "fmt"

--- a/executor/util/provision.go
+++ b/executor/util/provision.go
@@ -1,12 +1,12 @@
 package util
 
 import (
-	. "fmt"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/spacemonkeygo/errors"
-
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/input/dispatch"
 	"polydawn.net/repeatr/output/dispatch"
@@ -14,9 +14,9 @@ import (
 
 // Run inputs
 // TODO: run all simultaneously, waitgroup out the errors
-func ProvisionInputs(inputs []def.Input, rootfs string) {
+func ProvisionInputs(inputs []def.Input, rootfs string, journal io.Writer) {
 	for x, input := range inputs {
-		Println("Provisioning input", x+1, input.Type, "to", input.Location)
+		fmt.Fprintln(journal, "Provisioning input", x+1, input.Type, "to", input.Location)
 		path := filepath.Join(rootfs, input.Location)
 
 		// Ensure that the parent folder of this input exists
@@ -35,7 +35,7 @@ func ProvisionInputs(inputs []def.Input, rootfs string) {
 
 // Output folders should exist
 // TODO: discussion
-func ProvisionOutputs(outputs []def.Output, rootfs string) {
+func ProvisionOutputs(outputs []def.Output, rootfs string, journal io.Writer) {
 	for _, output := range outputs {
 		path := filepath.Join(rootfs, output.Location)
 		err := os.MkdirAll(path, 0755)
@@ -47,16 +47,16 @@ func ProvisionOutputs(outputs []def.Output, rootfs string) {
 
 // Run outputs
 // TODO: run all simultaneously, waitgroup out the errors
-func PreserveOutputs(outputs []def.Output, rootfs string) []def.Output {
+func PreserveOutputs(outputs []def.Output, rootfs string, journal io.Writer) []def.Output {
 	for x, output := range outputs {
-		Println("Persisting output", x+1, output.Type, "from", output.Location)
+		fmt.Fprintln(journal, "Persisting output", x+1, output.Type, "from", output.Location)
 		// path := filepath.Join(rootfs, output.Location)
 
 		report := <-outputdispatch.Get(output).Apply(rootfs)
 		if report.Err != nil {
 			panic(report.Err)
 		}
-		Println("Output", x+1, "hash:", report.Output.Hash)
+		fmt.Fprintln(journal, "Output", x+1, "hash:", report.Output.Hash)
 	}
 
 	return outputs

--- a/repeatr.go
+++ b/repeatr.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	try.Do(func() {
-		cli.App.Run(os.Args)
+		cli.Main(os.Args, os.Stderr)
 	}).Catch(cli.Error, func(err *errors.Error) {
 		// Errors marked as valid user-facing issues get a nice
 		// pretty-printed route out, and may include specified exit codes.

--- a/repeatr.go
+++ b/repeatr.go
@@ -26,7 +26,12 @@ func main() {
 				"Repeatr was unable to complete your request!\n"+
 					"%s\n",
 				err)
-			os.Exit(int(cli.EXIT_USER))
+			// exit, taking the specified code if any.
+			code := errors.GetData(err, cli.ExitCodeKey)
+			if code == nil {
+				os.Exit(int(cli.EXIT_USER))
+			}
+			os.Exit(int(code.(cli.ExitCode)))
 		}
 	}).CatchAll(func(err error) {
 		// Errors that aren't marked as valid user-facing issues should be

--- a/repeatr.go
+++ b/repeatr.go
@@ -1,11 +1,80 @@
 package main
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
+	"time"
 
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
 	"polydawn.net/repeatr/cli"
 )
 
 func main() {
-	cli.App.Run(os.Args)
+	try.Do(func() {
+		cli.App.Run(os.Args)
+	}).Catch(cli.Error, func(err *errors.Error) {
+		// Errors marked as valid user-facing issues get a nice
+		// pretty-printed route out, and may include specified exit codes.
+		if isDebugMode() {
+			// in debug-mode, repanic all the way to death so that we get all of golang's built in log features.
+			panic(err)
+		} else {
+			// print nicely.
+			fmt.Fprintf(os.Stderr,
+				"Repeatr was unable to complete your request!\n"+
+					"%s\n",
+				err)
+			os.Exit(int(cli.EXIT_USER))
+		}
+	}).CatchAll(func(err error) {
+		// Errors that aren't marked as valid user-facing issues should be
+		// logged in preparation for a bug report.
+		if isDebugMode() {
+			// in debug-mode, repanic all the way to death so that we get all of golang's built in log features.
+			panic(err)
+		} else {
+			// save the error to a file.  we want to keep the stacks, but not scare away the user.
+			logPath, saveErr := saveErrorReport(err)
+			var saveMsg string
+			if saveErr == nil {
+				saveMsg = fmt.Sprintf("We've logged the full error to a file: %q.  Please include this in the report.", logPath)
+			} else {
+				saveMsg = fmt.Sprintf("Additionally, we were unable to save a full log of the problem (\"%s\").", saveErr)
+			}
+			fmt.Fprintf(os.Stderr,
+				"Repeatr encountered a serious issue and was unable to complete your request!\n"+
+					"Please file an issue to help us fix it.\n"+
+					saveMsg+"\n"+
+					"\n"+
+					"This is the short version of the problem:\n"+
+					"%s\n",
+				err)
+			os.Exit(int(cli.EXIT_UNKNOWNPANIC))
+		}
+	})
+}
+
+func isDebugMode() bool {
+	// if either "DEBUG" or "REPEATR_DEBUG" env vars are set, we're in debug mode.
+	return len(os.Getenv("DEBUG")) != 0 || len(os.Getenv("REPEATR_DEBUG")) != 0
+}
+
+func saveErrorReport(caught error) (string, error) {
+	logFile, err := ioutil.TempFile(os.TempDir(), "repeatr-error-report-")
+	if err != nil {
+		return "", err
+	}
+	defer logFile.Close()
+	fmt.Fprintf(logFile, "Repeatr error report\n")
+	fmt.Fprintf(logFile, "====================\n")
+	fmt.Fprintf(logFile, "Date: %s\n", time.Now())
+	fmt.Fprintf(logFile, "\n")
+	fmt.Fprintf(logFile, "Full error:\n")
+	fmt.Fprintf(logFile, "-----------\n")
+	fmt.Fprintf(logFile, "%s\n", caught)
+	fmt.Fprintf(logFile, "\n")
+	// TODO full stack viewed from here.  yank the formatting stuff from spacemonkey errors
+	return logFile.Name(), nil
 }

--- a/repeatr.go
+++ b/repeatr.go
@@ -51,11 +51,13 @@ func main() {
 			fmt.Fprintf(os.Stderr,
 				"Repeatr encountered a serious issue and was unable to complete your request!\n"+
 					"Please file an issue to help us fix it.\n"+
-					saveMsg+"\n"+
+					"%s\n"+
 					"\n"+
 					"This is the short version of the problem:\n"+
 					"%s\n",
-				err)
+				saveMsg,
+				errors.GetMessage(err),
+			)
 			os.Exit(int(cli.EXIT_UNKNOWNPANIC))
 		}
 	})
@@ -75,10 +77,15 @@ func saveErrorReport(caught error) (string, error) {
 	fmt.Fprintf(logFile, "Repeatr error report\n")
 	fmt.Fprintf(logFile, "====================\n")
 	fmt.Fprintf(logFile, "Date: %s\n", time.Now())
+	fmt.Fprintf(logFile, "Briefly: %s\n", errors.GetMessage(caught))
 	fmt.Fprintf(logFile, "\n")
 	fmt.Fprintf(logFile, "Full error:\n")
 	fmt.Fprintf(logFile, "-----------\n")
 	fmt.Fprintf(logFile, "%s\n", caught)
+	fmt.Fprintf(logFile, "\n")
+	fmt.Fprintf(logFile, "Structure:\n")
+	fmt.Fprintf(logFile, "-----------\n")
+	fmt.Fprintf(logFile, "%#v\n", caught)
 	fmt.Fprintf(logFile, "\n")
 	// TODO full stack viewed from here.  yank the formatting stuff from spacemonkey errors
 	return logFile.Name(), nil

--- a/scheduler/group/group.go
+++ b/scheduler/group/group.go
@@ -1,6 +1,7 @@
 package group
 
 import (
+	"io/ioutil"
 	"runtime"
 
 	"polydawn.net/repeatr/def"
@@ -59,8 +60,7 @@ func (s *Scheduler) Schedule(f def.Formula) (def.JobID, <-chan def.Job) {
 // Run jobs one at a time
 func (s *Scheduler) Run() {
 	for h := range s.queue {
-
-		job := s.executor.Start(h.forumla, h.id)
+		job := s.executor.Start(h.forumla, h.id, ioutil.Discard)
 		h.response <- job
 		job.Wait()
 	}

--- a/scheduler/linear/linear.go
+++ b/scheduler/linear/linear.go
@@ -1,6 +1,8 @@
 package linear
 
 import (
+	"io/ioutil"
+
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/lib/guid"
@@ -54,7 +56,7 @@ func (s *Scheduler) Schedule(f def.Formula) (def.JobID, <-chan def.Job) {
 func (s *Scheduler) Run() {
 	for h := range s.queue {
 
-		job := s.executor.Start(h.forumla, h.id)
+		job := s.executor.Start(h.forumla, h.id, ioutil.Discard)
 		h.response <- job
 		job.Wait()
 	}


### PR DESCRIPTION
All output from the CLI can now be shunted to any `io.Writer`.  Tests can use this to check output.  Right now, existing tests route everything to `ioutil.Discard` for lack of any useful assertions.

This cleans up *all* output leaking through test reports, making reading much more pleasant again.

Introduced new errors for user-facing messages, with graceful reporting for and a mechanism for custom exit codes, as well as a polite logging mechanism for unexpected errors.