### PR TITLE
Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,7 @@ script:
   - ./goad install
   - ./lib/integration/assets.sh
   - sudo bash -c "export PATH=$PATH:$PWD/assets ; export GOROOT=$GOROOT ; ./goad test" # unescaped dollars are eval'd in an implicit first shell
+  - sudo ./goad sanity
 
 notifications:
   email: false
-  irc:
-    channels:
-      - "chat.freenode.net##polydawn"
-    on_success: always
-    on_failure: always
-    template:
-      - "%{repository_name}: %{commit} on %{branch} by %{author}: %{result}. %{build_url} %{commit_message}"
-    skip_join: true

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -28,7 +28,7 @@ func Main(args []string, journal io.Writer) {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "executor, e",
-					Value: "nsinit",
+					Value: "chroot",
 					Usage: "Which executor to use",
 				},
 				cli.StringFlag{

--- a/goad
+++ b/goad
@@ -72,6 +72,10 @@ else
 		shift
 		"$GOPATH/bin/$name" "$@"
 		;;
+	sanity)
+		# A placeholder for an eventually-larger set of full-stack invoke-binary tests.
+		"$GOPATH/bin/$name" run -e chroot -s linear -i lib/integration/wait.json
+		;;
 	fmt)
 		go fmt "$SUBSECTION"
 		;;

--- a/lib/integration/wait.json
+++ b/lib/integration/wait.json
@@ -7,7 +7,7 @@
 		}
 	],
 	"Accents": {
-		"Entrypoint": [ "echo", "Hello from repeatr!" ]
+		"Entrypoint": [ "bash", "-c", "echo hello1; sleep .5; echo hello2; sleep .5; echo hello3" ]
 	},
 	"Outputs": [
 		{


### PR DESCRIPTION
* Added a top-level sanity check that invokes the `repeatr` binary.
* Added said sanity check to Travis.
* Set `basic.json` back to its initial state since the Mux race condition was resolved.
* Moved the wait-streaming example to a new file `wait.json`, which the sanity check uses.
* Set the default executor to chroot, as that's the more mature and easier-to-use executor right now.
* Got rid of IRC notification settings because Travis is clearly insane.