### PR TITLE
Executor failsafe results

### DIFF
--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -44,10 +44,14 @@ func (e *Executor) Start(f def.Formula, id def.JobID, journal io.Writer) def.Job
 			// spool our output to a muxed stream
 			var strm streamer.Mux
 			strm = streamer.CborFileMux(filepath.Join(dir, "log"))
-
 			outS := strm.Appender(1)
 			errS := strm.Appender(2)
 			job.Reader = strm.Reader(1, 2)
+			defer func() {
+				// Regardless of how the job ends (or even if it fails the remaining setup), output streams must be terminated.
+				outS.Close()
+				errS.Close()
+			}()
 
 			// Job is ready to stream process output
 			close(jobReady)
@@ -106,13 +110,6 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 	cmd.Stdin = nil
 	cmd.Stdout = outS
 	cmd.Stderr = errS
-
-	defer func() {
-		// Close output streams.
-		// (I thought exec should do this already...?  But doesn't seem to.)
-		cmd.Stdout.(io.WriteCloser).Close()
-		cmd.Stderr.(io.WriteCloser).Close()
-	}()
 
 	// launch execution.
 	// transform gosh's typed errors to repeatr's hierarchical errors.

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -76,8 +76,8 @@ func Test(t *testing.T) {
 				msg, err := ioutil.ReadAll(job.OutputReader())
 				So(err, ShouldBeNil)
 				So(string(msg), ShouldEqual, "echococo\n")
+				So(job.Wait().Error, ShouldBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 0)
-
 			})
 
 			Convey("The executor should be able to check exit codes", func() {
@@ -87,6 +87,7 @@ func Test(t *testing.T) {
 
 				job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
 				So(job, ShouldNotBeNil)
+				So(job.Wait().Error, ShouldBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 14)
 			})
 
@@ -110,6 +111,7 @@ func Test(t *testing.T) {
 
 					job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
 					So(job, ShouldNotBeNil)
+					So(job.Wait().Error, ShouldBeNil)
 					So(job.Wait().ExitCode, ShouldEqual, 0)
 					msg, err := ioutil.ReadAll(job.OutputReader())
 					So(err, ShouldBeNil)

--- a/executor/nsinit/nsinit.go
+++ b/executor/nsinit/nsinit.go
@@ -69,10 +69,13 @@ func (e *Executor) Start(f def.Formula, id def.JobID, journal io.Writer) def.Job
 
 // Executes a job, catching any panics.
 func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
-	var r def.JobResult
+	r := def.JobResult{
+		ID:       j.Id(),
+		ExitCode: -1,
+	}
 
 	try.Do(func() {
-		r = e.Execute(f, j, d, outS, errS, journal)
+		e.Execute(f, j, d, &r, outS, errS, journal)
 	}).Catch(executor.Error, func(err *errors.Error) {
 		r.Error = err
 	}).Catch(input.Error, func(err *errors.Error) {
@@ -87,15 +90,7 @@ func (e *Executor) Run(f def.Formula, j def.Job, d string, outS, errS io.WriteCl
 }
 
 // Execute a formula in a specified directory. MAY PANIC.
-func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.WriteCloser, journal io.Writer) def.JobResult {
-
-	result := def.JobResult{
-		ID:       j.Id(),
-		Error:    nil,
-		ExitCode: 0, //TODO: gosh
-		Outputs:  []def.Output{},
-	}
-
+func (e *Executor) Execute(f def.Formula, j def.Job, d string, result *def.JobResult, outS, errS io.WriteCloser, journal io.Writer) {
 	// Dedicated rootfs folder to distinguish container from nsinit noise
 	rootfs := filepath.Join(d, "rootfs")
 
@@ -146,5 +141,4 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, outS, errS io.Wri
 
 	// Save outputs
 	result.Outputs = util.PreserveOutputs(f.Outputs, rootfs, journal)
-	return result
 }

--- a/lib/flak/assist.go
+++ b/lib/flak/assist.go
@@ -27,7 +27,7 @@ func GetTempDir(dirs ...string) string {
 	tempPath := filepath.Join(dir...)
 
 	// Tempdir wants parent path to exist
-	err := os.MkdirAll(tempPath, 0600)
+	err := os.MkdirAll(tempPath, 0755)
 	if err != nil {
 		panic(errors.IOError.Wrap(err))
 	}
@@ -51,7 +51,7 @@ func WithDir(f func(string), dirs ...string) {
 	tempPath := filepath.Join(dirs...)
 
 	// Tempdir wants parent path to exist
-	err := os.MkdirAll(tempPath, 0600)
+	err := os.MkdirAll(tempPath, 0755)
 	if err != nil {
 		panic(errors.IOError.Wrap(err))
 	}


### PR DESCRIPTION
Cleanups and fail-safe behavior for some executor failure modes.

- Always close stream muxes
- Set default values for more return codes.  (Zero values were overlaping with valid values (namely, with exit codes), so initializing an unambiguous value is a big deal for maintaining appearances of sanity in error handling paths.  As a specific example, it makes sense for assertions that the exit code is zero-aka-success should fail if the process never launched.)
- Add some more error condition checks in tests that always should've been there.