### PR TITLE
Tar input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - ./lib/integration/assets.sh
   - sudo bash -c "export PATH=$PATH:$PWD/assets ; export GOROOT=$GOROOT ; ./goad test" # unescaped dollars are eval'd in an implicit first shell
   - sudo ./goad sanity
+  - sudo ./lib/integration/runAll.sh
 
 notifications:
   email: false

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -42,6 +42,18 @@ func Test(t *testing.T) {
 				result := e.Start(formula, def.JobID(guid.New()), ioutil.Discard).Wait()
 				So(result.Error, testutil.ShouldBeErrorClass, input.Error)
 			})
+
+			Convey("The job exit code should clearly indicate failure", FailureContinues, func() {
+				formula.Accents = def.Accents{
+					Entrypoint: []string{"echo", "echococo"},
+				}
+				job := e.Start(formula, def.JobID(guid.New()), ioutil.Discard)
+				So(job, ShouldNotBeNil)
+				So(job.Wait().Error, ShouldNotBeNil)
+				// Even though one should clearly also check the error status,
+				//  zero here could be very confusing, so jobs that error before start should be -1.
+				So(job.Wait().ExitCode, ShouldEqual, -1)
+			})
 		}),
 	)
 

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -55,6 +55,7 @@ func Test(t *testing.T) {
 					{
 						Type:     "tar",
 						Location: "/",
+						Hash:     "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
 						URI:      filepath.Join(projPath, "assets/ubuntu.tar.gz"),
 					},
 				},

--- a/goad
+++ b/goad
@@ -57,8 +57,9 @@ else
 		git submodule update --init
 		;;
 	test)
-		go test -i "$SUBSECTION" 2> >(grep --color -E "$highlighRegex") &&
-		go test -v "$SUBSECTION" 2> >(grep --color -E "$highlighRegex") && {
+		set +e ; shift ; shift ; set -e
+		go test -i "$SUBSECTION" "$@" 2> >(grep --color -E "$highlighRegex") &&
+		go test -v "$SUBSECTION" "$@" 2> >(grep --color -E "$highlighRegex") && {
 			echo -e "\n\E[1;32mall tests green.\E[0;m"
 		} || {
 			echo -e "\n\E[1;41msome tests failed!\E[0;m"

--- a/input/dispatch/dispatch.go
+++ b/input/dispatch/dispatch.go
@@ -5,6 +5,7 @@ import (
 	"polydawn.net/repeatr/input"
 	"polydawn.net/repeatr/input/dir"
 	"polydawn.net/repeatr/input/tar"
+	"polydawn.net/repeatr/input/tar2"
 )
 
 func Get(desire def.Input) input.Input {
@@ -14,6 +15,8 @@ func Get(desire def.Input) input.Input {
 	case "dir":
 		input = dir.New(desire)
 	case "tar":
+		input = tar2.New(desire)
+	case "exec-tar":
 		input = tar.New(desire)
 	default:
 		panic(def.ValidationError.New("No such input %s", desire))

--- a/input/errors.go
+++ b/input/errors.go
@@ -14,6 +14,25 @@ var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not
 var InputHashMismatchError *errors.ErrorClass = Error.NewClass("InputHashMismatchError")
 
 /*
+	Indicates that an error getting the data an input described.
+	(As contrasted with a `TargetFilesystemUnavailableError`, which is
+	an error that comes while trying to unpack the data source onto a
+	local filesystem for use.)
+
+	Examples include a URI that specified a file that doesn't exist, or
+	an IO error later while reading from that source, etc.
+
+*/
+var DataSourceUnavailableError *errors.ErrorClass = Error.NewClass("InputDataSourceUnavailableError")
+
+// Convenience method for wrapping io errors.
+func DataSourceUnavailableIOError(err error) *errors.Error {
+	return DataSourceUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
+}
+
+// REVIEW: should InputHashMismatchError be a subtype of DataSourceUnavailableError?  (leaning towards probably yes)
+
+/*
 	Indicates that the target filesystem (the one given to `Apply`) had some error.
 */
 var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("InputTargetFilesystemUnavailableError")

--- a/input/errors.go
+++ b/input/errors.go
@@ -7,13 +7,6 @@ import (
 var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
 
 /*
-	Indicates that the input failed to obtain data that correctly
-	matches the hash specifying the input.  This may mean there have
-	been data integrity issues in the storage or transport systems involved.
-*/
-var InputHashMismatchError *errors.ErrorClass = Error.NewClass("InputHashMismatchError")
-
-/*
 	Indicates that an error getting the data an input described.
 	(As contrasted with a `TargetFilesystemUnavailableError`, which is
 	an error that comes while trying to unpack the data source onto a
@@ -30,7 +23,14 @@ func DataSourceUnavailableIOError(err error) *errors.Error {
 	return DataSourceUnavailableError.Wrap(errors.IOError.Wrap(err)).(*errors.Error)
 }
 
-// REVIEW: should InputHashMismatchError be a subtype of DataSourceUnavailableError?  (leaning towards probably yes)
+/*
+	Indicates that the input failed to obtain data that correctly
+	matches the hash specifying the input.  This means there have
+	been data integrity issues in the storage or transport systems involved --
+	either the transport is having reliability issues, or, this may be an
+	active attack (i.e. MITM).
+*/
+var InputHashMismatchError *errors.ErrorClass = DataSourceUnavailableError.NewClass("InputHashMismatchError")
 
 /*
 	Indicates that the target filesystem (the one given to `Apply`) had some error.

--- a/input/tar/tar_input.go
+++ b/input/tar/tar_input.go
@@ -20,7 +20,9 @@ type Input struct {
 }
 
 func New(spec def.Input) *Input {
-	if spec.Type != Type {
+	switch spec.Type {
+	case Type, "exec-tar":
+	default:
 		panic(errors.ProgrammerError.New("This input implementation supports definitions of type %q, not %q", Type, spec.Type))
 	}
 	return &Input{

--- a/input/tar2/compression.go
+++ b/input/tar2/compression.go
@@ -1,0 +1,69 @@
+package tar2
+
+import (
+	"bufio"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+)
+
+type Compression int
+
+const (
+	Uncompressed Compression = iota
+	Bzip2
+	Gzip
+	Xz
+)
+
+func (compression *Compression) Extension() string {
+	switch *compression {
+	case Uncompressed:
+		return "tar"
+	case Bzip2:
+		return "tar.bz2"
+	case Gzip:
+		return "tar.gz"
+	case Xz:
+		return "tar.xz"
+	}
+	return "[unknown]"
+}
+
+func DetectCompression(source []byte) Compression {
+	// Compression detection patterns borrowed from docker/pkg/archive/archive.go, where they also reside under an Apache v2 license
+	for compression, m := range map[Compression][]byte{
+		Bzip2: {0x42, 0x5A, 0x68},
+		Gzip:  {0x1F, 0x8B, 0x08},
+		Xz:    {0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00},
+	} {
+		if bytes.Compare(m, source[:len(m)]) == 0 {
+			return compression
+		}
+	}
+	return Uncompressed
+}
+
+func Decompress(stream io.Reader) (io.Reader, error) {
+	buf := bufio.NewReaderSize(stream, 8*1024)
+	bs, err := buf.Peek(10)
+	if err != nil {
+		return nil, err
+	}
+
+	compression := DetectCompression(bs)
+	switch compression {
+	case Uncompressed:
+		return buf, nil
+	case Gzip:
+		return gzip.NewReader(buf)
+	case Bzip2:
+		return bzip2.NewReader(buf), nil
+	case Xz:
+		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	default:
+		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+	}
+}

--- a/input/tar2/compression.go
+++ b/input/tar2/compression.go
@@ -47,7 +47,7 @@ func DetectCompression(source []byte) Compression {
 }
 
 func Decompress(stream io.Reader) (io.Reader, error) {
-	buf := bufio.NewReaderSize(stream, 8*1024)
+	buf := bufio.NewReaderSize(stream, 32*1024)
 	bs, err := buf.Peek(10)
 	if err != nil {
 		return nil, err

--- a/input/tar2/goconvey.goconvey
+++ b/input/tar2/goconvey.goconvey
@@ -1,0 +1,1 @@
+-timeout=30s

--- a/input/tar2/goconvey.goconvey
+++ b/input/tar2/goconvey.goconvey
@@ -1,1 +1,2 @@
--timeout=30s
+#-timeout=30s
+-short

--- a/input/tar2/tar_input.go
+++ b/input/tar2/tar_input.go
@@ -28,7 +28,7 @@ type Input struct {
 	hasherFactory func() hash.Hash
 }
 
-func New(spec def.Input) *Input {
+func New(spec def.Input) input.Input {
 	if spec.Type != Type {
 		panic(errors.ProgrammerError.New("This input implementation supports definitions of type %q, not %q", Type, spec.Type))
 	}

--- a/input/tar2/tar_input.go
+++ b/input/tar2/tar_input.go
@@ -1,0 +1,146 @@
+package tar2
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
+	"hash"
+	"io"
+	"os"
+
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/input"
+	"polydawn.net/repeatr/lib/fs"
+	"polydawn.net/repeatr/lib/fshash"
+	"polydawn.net/repeatr/lib/fspatch"
+)
+
+const Type = "tar"
+
+var _ input.Input = &Input{} // interface assertion
+
+type Input struct {
+	spec          def.Input
+	hasherFactory func() hash.Hash
+}
+
+func New(spec def.Input) *Input {
+	if spec.Type != Type {
+		panic(errors.ProgrammerError.New("This input implementation supports definitions of type %q, not %q", Type, spec.Type))
+	}
+	_, err := os.Stat(spec.URI)
+	if os.IsNotExist(err) {
+		panic(input.DataSourceUnavailableError.New("Input URI %q must be a tar file", spec.URI))
+	}
+	return &Input{
+		spec:          spec,
+		hasherFactory: sha512.New384,
+	}
+}
+
+func (i Input) Apply(destinationRoot string) <-chan error {
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		try.Do(func() {
+			// do make a dir for untaring into.
+			// tars may specify permission and time bits for their top dir, but if not, we'll start with sane defaults.
+			err := os.MkdirAll(destinationRoot, 0755)
+			if err != nil {
+				panic(input.TargetFilesystemUnavailableIOError(err))
+			}
+			// daemon uid and gid are fine for now but force a constant mtime.
+			if err := fspatch.LUtimesNano(destinationRoot, def.Epochwhen, def.Epochwhen); err != nil {
+				panic(input.TargetFilesystemUnavailableIOError(err))
+			}
+
+			// open the tar file; preparing decompression as necessary
+			file, err := os.OpenFile(i.spec.URI, os.O_RDONLY, 0755)
+			if err != nil {
+				panic(input.DataSourceUnavailableIOError(err))
+			}
+			defer file.Close()
+			reader, err := Decompress(file)
+			if err != nil {
+				panic(input.DataSourceUnavailableError.New("could not start decompressing: %s", err))
+			}
+			tarReader := tar.NewReader(reader)
+
+			// unroll the tar, copying and accumulating data for integrity check
+			bucket := &fshash.MemoryBucket{}
+			walk(tarReader, destinationRoot, bucket, i.hasherFactory)
+
+			// hash whole tree
+			actualTreeHash, _ := fshash.Hash(bucket, i.hasherFactory)
+
+			// verify total integrity
+			expectedTreeHash, err := base64.URLEncoding.DecodeString(i.spec.Hash)
+			if !bytes.Equal(actualTreeHash, expectedTreeHash) {
+				done <- input.InputHashMismatchError.New("expected hash %q, got %q", i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
+			}
+		}).Catch(input.Error, func(err *errors.Error) {
+			done <- err
+		}).CatchAll(func(err error) {
+			// All errors we emit will be under `input.Error`'s type.
+			// Every time we hit this UnknownError path, we should consider it a bug until that error is categorized.
+			done <- input.UnknownError.Wrap(err).(*errors.Error)
+		}).Done()
+	}()
+	return done
+}
+
+func walk(tr *tar.Reader, destBasePath string, bucket fshash.Bucket, hasherFactory func() hash.Hash) error {
+	for {
+		thdr, err := tr.Next()
+		if err == io.EOF {
+			break // end of archive
+		}
+		if err != nil {
+			panic(input.DataSourceUnavailableError.New("corrupt tar: %s", err))
+		}
+		hdr := fs.Metadata(*thdr)
+		// filter/sanify values:
+		// times should never be go's zero value; replace those with epoch
+		if hdr.ModTime.IsZero() {
+			hdr.ModTime = def.Epochwhen
+		}
+		if hdr.AccessTime.IsZero() {
+			hdr.AccessTime = def.Epochwhen
+		}
+		// place the file
+		switch hdr.Typeflag {
+		case tar.TypeReg:
+			reader := &hashingReader{
+				r:      tr,
+				hasher: hasherFactory(),
+			}
+			fs.PlaceFile(destBasePath, hdr, reader)
+			bucket.Record(hdr, reader.hasher.Sum(nil))
+		default:
+			fs.PlaceFile(destBasePath, hdr, tr)
+			bucket.Record(hdr, nil)
+			// TODO fixup dir times afterwards
+		}
+	}
+	return nil
+}
+
+/*
+	Proxies a reader, hashing the stream as it's read.
+	(This is useful if using `io.Copy` to move bytes from a reader to
+	a writer, and you want to use that goroutine to power the hashing as
+	well but replacing the writer with a multiwriter is out of bounds.)
+*/
+type hashingReader struct {
+	r      io.Reader
+	hasher hash.Hash
+}
+
+func (r *hashingReader) Read(b []byte) (int, error) {
+	n, err := r.r.Read(b)
+	r.hasher.Write(b[:n])
+	return n, err
+}

--- a/input/tar2/tar_input_test.go
+++ b/input/tar2/tar_input_test.go
@@ -1,0 +1,52 @@
+package tar2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/polydawn/gosh"
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/testutil"
+	"polydawn.net/repeatr/testutil/filefixture"
+)
+
+func TestTarCompat(t *testing.T) {
+	projPath, _ := os.Getwd()
+	projPath = filepath.Dir(filepath.Dir(projPath))
+
+	testutil.Convey_IfHaveRoot("Applying a full ubuntu tarball should produce a filesystem", t, testutil.WithTmpdir(func() {
+		inputSpec := def.Input{
+			Type: "tar",
+			Hash: "HlC6c5GvyYQkB8Jtb8UeNFnYgV83la-MBwp66pK73QMfDpz9ScjeYrLwudvtjWiP",
+			URI:  filepath.Join(projPath, "assets/ubuntu.tar.gz"),
+		}
+		input := New(inputSpec)
+
+		// apply it; hope it doesn't blow up
+		err := <-input.Apply("data")
+		So(err, ShouldBeNil)
+
+		// do a native untar; since we don't have an upfront fixture
+		//  for this thing, we'll compare the two as filesystems.
+		// this is not well isolated from the host; consider improving that a todo.
+		os.Mkdir("./untar", 0755)
+		tarProc := gosh.Gosh(
+			"tar",
+			"-xf", filepath.Join(projPath, "assets/ubuntu.tar.gz"),
+			"-C", "./untar",
+			gosh.NullIO,
+		).RunAndReport()
+		So(tarProc.GetExitCode(), ShouldEqual, 0)
+
+		// scan and compare
+		scan1 := filefixture.Scan("./data")
+		scan2 := filefixture.Scan("./untar")
+		// boy, that's entertaining though: gnu tar does all the same stuff,
+		//  except it doesn't honor our nanosecond timings.
+		// also exclude bodies because they're *big*.
+		comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareMtime &^ filefixture.CompareBody
+		So(scan1.Describe(comparisonLevel), ShouldEqual, scan2.Describe(comparisonLevel))
+	}))
+}

--- a/input/tar2/tar_input_test.go
+++ b/input/tar2/tar_input_test.go
@@ -8,10 +8,16 @@ import (
 	"github.com/polydawn/gosh"
 	. "github.com/smartystreets/goconvey/convey"
 	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/input/tests"
 	"polydawn.net/repeatr/lib/fspatch"
+	"polydawn.net/repeatr/output/tar2"
 	"polydawn.net/repeatr/testutil"
 	"polydawn.net/repeatr/testutil/filefixture"
 )
+
+func TestCoreCompliance(t *testing.T) {
+	tests.CheckRoundTrip(t, "tar", tar2.New, New)
+}
 
 const ubuntuTarballHash = "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v"
 

--- a/input/tar2/tar_input_test.go
+++ b/input/tar2/tar_input_test.go
@@ -25,40 +25,44 @@ func TestTarCompat(t *testing.T) {
 	projPath, _ := os.Getwd()
 	projPath = filepath.Dir(filepath.Dir(projPath))
 
-	testutil.Convey_IfHaveRoot("Applying a full ubuntu tarball should produce a filesystem", t, testutil.WithTmpdir(func() {
-		inputSpec := def.Input{
-			Type: "tar",
-			Hash: ubuntuTarballHash,
-			URI:  filepath.Join(projPath, "assets/ubuntu.tar.gz"),
-		}
-		input := New(inputSpec)
+	testutil.Convey_IfHaveRoot("Unpacking tars should match exec untar", t, testutil.WithTmpdir(func() {
+		testutil.Convey_IfSlowTests("Given a fixture tarball containing ubuntu", func() {
+			inputSpec := def.Input{
+				Type: "tar",
+				Hash: ubuntuTarballHash,
+				URI:  filepath.Join(projPath, "assets/ubuntu.tar.gz"),
+			}
+			input := New(inputSpec)
 
-		// apply it; hope it doesn't blow up
-		err := <-input.Apply("data")
-		So(err, ShouldBeNil)
+			Convey("Repeatr and exec untar should have matching results", func() {
+				// apply it; hope it doesn't blow up
+				err := <-input.Apply("data")
+				So(err, ShouldBeNil)
 
-		// do a native untar; since we don't have an upfront fixture
-		//  for this thing, we'll compare the two as filesystems.
-		// this is not well isolated from the host; consider improving that a todo.
-		os.Mkdir("./untar", 0755)
-		tarProc := gosh.Gosh(
-			"tar",
-			"-xf", filepath.Join(projPath, "assets/ubuntu.tar.gz"),
-			"-C", "./untar",
-			gosh.NullIO,
-		).RunAndReport()
-		So(tarProc.GetExitCode(), ShouldEqual, 0)
-		// native untar does not have an opinion about the base dir...
-		// but our scans do, so, flatten that here
-		So(fspatch.LUtimesNano("./untar", def.Epochwhen, def.Epochwhen), ShouldBeNil)
+				// do a native untar; since we don't have an upfront fixture
+				//  for this thing, we'll compare the two as filesystems.
+				// this is not well isolated from the host; consider improving that a todo.
+				os.Mkdir("./untar", 0755)
+				tarProc := gosh.Gosh(
+					"tar",
+					"-xf", filepath.Join(projPath, "assets/ubuntu.tar.gz"),
+					"-C", "./untar",
+					gosh.NullIO,
+				).RunAndReport()
+				So(tarProc.GetExitCode(), ShouldEqual, 0)
+				// native untar does not have an opinion about the base dir...
+				// but our scans do, so, flatten that here
+				So(fspatch.LUtimesNano("./untar", def.Epochwhen, def.Epochwhen), ShouldBeNil)
 
-		// scan and compare
-		scan1 := filefixture.Scan("./data")
-		scan2 := filefixture.Scan("./untar")
-		// boy, that's entertaining though: gnu tar does all the same stuff,
-		//  except it doesn't honor our nanosecond timings.
-		// also exclude bodies because they're *big*.
-		comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareSubsecond &^ filefixture.CompareBody
-		So(scan1.Describe(comparisonLevel), ShouldEqual, scan2.Describe(comparisonLevel))
+				// scan and compare
+				scan1 := filefixture.Scan("./data")
+				scan2 := filefixture.Scan("./untar")
+				// boy, that's entertaining though: gnu tar does all the same stuff,
+				//  except it doesn't honor our nanosecond timings.
+				// also exclude bodies because they're *big*.
+				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareSubsecond &^ filefixture.CompareBody
+				So(scan1.Describe(comparisonLevel), ShouldEqual, scan2.Describe(comparisonLevel))
+			})
+		})
 	}))
 }

--- a/input/tar2/tar_input_test.go
+++ b/input/tar2/tar_input_test.go
@@ -12,6 +12,8 @@ import (
 	"polydawn.net/repeatr/testutil/filefixture"
 )
 
+const ubuntuTarballHash = "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v"
+
 func TestTarCompat(t *testing.T) {
 	projPath, _ := os.Getwd()
 	projPath = filepath.Dir(filepath.Dir(projPath))
@@ -19,7 +21,7 @@ func TestTarCompat(t *testing.T) {
 	testutil.Convey_IfHaveRoot("Applying a full ubuntu tarball should produce a filesystem", t, testutil.WithTmpdir(func() {
 		inputSpec := def.Input{
 			Type: "tar",
-			Hash: "HlC6c5GvyYQkB8Jtb8UeNFnYgV83la-MBwp66pK73QMfDpz9ScjeYrLwudvtjWiP",
+			Hash: ubuntuTarballHash,
 			URI:  filepath.Join(projPath, "assets/ubuntu.tar.gz"),
 		}
 		input := New(inputSpec)

--- a/input/tests/input_tests.go
+++ b/input/tests/input_tests.go
@@ -1,0 +1,63 @@
+/*
+	Tests for use in each input implementation.
+	Import and invoke in each implementation's package to get coverage
+	within that package.
+*/
+package tests
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/input"
+	"polydawn.net/repeatr/output"
+	"polydawn.net/repeatr/testutil"
+	"polydawn.net/repeatr/testutil/filefixture"
+)
+
+type InputFactory func(def.Input) input.Input
+type OutputFactory func(def.Output) output.Output
+
+/*
+	Checks round-trip hash consistency for a pair of input and output systems.
+
+	- Creates a fixture filesystem
+	- Scans it with the output system
+	- Places it in a new filesystem with the input system and the scanned hash
+	- Checks the new filesystem matches the original
+*/
+func CheckRoundTrip(t *testing.T, kind string, newOutput OutputFactory, newInput InputFactory) {
+	testutil.Convey_IfHaveRoot("Scanning and replacing a filesystem should agree on hash and content", t, func() {
+		for _, fixture := range filefixture.All {
+			Convey(fmt.Sprintf("- Fixture %q", fixture.Name), FailureContinues, testutil.WithTmpdir(func() {
+				// setup fixture
+				fixture.Create("./fixture")
+
+				// scan with output
+				scanner := newOutput((def.Output{
+					Type: kind,
+					URI:  "./output.dump",
+				}))
+				report := <-scanner.Apply("./fixture")
+				So(report.Err, ShouldBeNil)
+
+				// place with input (along the way, requires hash match)
+				input := newInput((def.Input{
+					Type: kind,
+					Hash: report.Output.Hash,
+					URI:  "./output.dump",
+				}))
+				err := <-input.Apply("./unpack")
+				So(err, ShouldBeNil)
+
+				// check filesystem to match original fixture
+				// (do this check even if the input raised a hash mismatch, because it can help show why)
+				rescan := filefixture.Scan("./unpack")
+				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareSubsecond
+				So(rescan.Describe(comparisonLevel), ShouldEqual, fixture.Describe(comparisonLevel))
+			}))
+		}
+	})
+}

--- a/lib/fs/emplacements.go
+++ b/lib/fs/emplacements.go
@@ -67,7 +67,7 @@ func PlaceFile(destBasePath string, hdr Metadata, body io.Reader) {
 
 	switch hdr.Typeflag {
 	case tar.TypeDir:
-		if hdr.Name == "." {
+		if hdr.Name == "./" {
 			// for the base dir only:
 			// the dir may exist; we'll just chown+chmod+chtime it.
 			// there is no race-free path through this btw, unless you know of a way to lstat and mkdir in the same syscall.

--- a/lib/fs/walk.go
+++ b/lib/fs/walk.go
@@ -19,10 +19,7 @@ type WalkFunc func(filenode *FilewalkNode) error
 
 	All paths begin in `./`, and directory names are slash-suffixed.
 	E.g. you'll see a series like `{"./", "./a/", "./a/b"}`, etc.
-	This is identical in behavior to `filepath.Clean` having been called on each path,
-	with the exception that prefix and directory suffixed.  (The reason for
-	these behaviors is to have the results naturally sort into a tree ordering;
-	see also the comments on buckets in the `lib/fshash` package.)
+	This matches the behaviors described by `Normalize` in the `lib/fshash`.
 
 	Symlinks are not followed.
 

--- a/lib/fshash/bucket.go
+++ b/lib/fshash/bucket.go
@@ -14,6 +14,13 @@ import (
 	This is to make it possible to range over the filesystem out of order and
 	construct a total hash of the system in order later.
 
+	Directory names must be slash-suffixed.
+	Note that this diverges with https://golang.org/pkg/path/#Clean behavior.
+	(Also note that this matches the specifications for tar formats, though that's a coincidence.)
+	The overriding consideration is that slash-suffixed dirnames
+	naturally sort such that parent dirs come (immediately) before their children,
+	which dramatically simplifies processing.
+
 	Currently this just has an in-memory implementation, but something backed by
 	e.g. boltdb for really large file trees would also make sense.
 */
@@ -64,14 +71,14 @@ var PathCollision *errors.ErrorClass = InvalidFilesystem.NewClass("PathCollision
 var MissingTree *errors.ErrorClass = InvalidFilesystem.NewClass("MissingTree")
 
 /*
-	Node used for the root (Name = ".") path, if one isn't provided.
+	Node used for the root (Name = "./") path, if one isn't provided.
 */
 var DefaultRoot Record
 
 func init() {
 	DefaultRoot = Record{
 		Metadata: fs.Metadata{
-			Name:       ".",
+			Name:       "./",
 			Typeflag:   tar.TypeDir,
 			Mode:       0755,
 			ModTime:    def.Epochwhen,

--- a/lib/fshash/bucket.go
+++ b/lib/fshash/bucket.go
@@ -17,6 +17,7 @@ import (
 type Bucket interface {
 	Record(metadata fs.Metadata, contentHash []byte) // record a file into the bucket
 	Iterator() (rootRecord RecordIterator)           // return a treewalk root that does a traversal ordered by path
+	Length() int
 }
 
 type Record struct {

--- a/lib/fshash/bucket.go
+++ b/lib/fshash/bucket.go
@@ -43,14 +43,14 @@ type RecordIterator interface {
 var InvalidFilesystem *errors.ErrorClass = errors.NewClass("InvalidFilesystem")
 
 /*
-	FileCollision is reported when the same file path is submitted to a `Bucket`
+	PathCollision is reported when the same file path is submitted to a `Bucket`
 	more than once.  (Some formats, for example tarballs, allow the same filename
 	to be recorded twice.  We consider this poor behavior since most actual
 	filesystems of course will not tolerate this, and also because it begs the
 	question of which should be sorted first when creating a deterministic
 	hash of the whole tree.)
 */
-var FileCollision *errors.ErrorClass = InvalidFilesystem.NewClass("FileCollision")
+var PathCollision *errors.ErrorClass = InvalidFilesystem.NewClass("PathCollision")
 
 /*
 	MissingTree is reported when iteration over a filled bucket encounters

--- a/lib/fshash/bucket.go
+++ b/lib/fshash/bucket.go
@@ -1,7 +1,10 @@
 package fshash
 
 import (
+	"archive/tar"
+
 	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/lib/fs"
 	"polydawn.net/repeatr/lib/treewalk"
 )
@@ -59,6 +62,25 @@ var PathCollision *errors.ErrorClass = InvalidFilesystem.NewClass("PathCollision
 	and there's no entries for "./a", it's a MissingTree error.
 */
 var MissingTree *errors.ErrorClass = InvalidFilesystem.NewClass("MissingTree")
+
+/*
+	Node used for the root (Name = ".") path, if one isn't provided.
+*/
+var DefaultRoot Record
+
+func init() {
+	DefaultRoot = Record{
+		Metadata: fs.Metadata{
+			Name:       ".",
+			Typeflag:   tar.TypeDir,
+			Mode:       0755,
+			ModTime:    def.Epochwhen,
+			AccessTime: def.Epochwhen,
+			// other fields (uid, gid) have acceptable "zero" values.
+		},
+		ContentHash: nil,
+	}
+}
 
 // for sorting
 type linesByFilepath []Record

--- a/lib/fshash/bucket_memory.go
+++ b/lib/fshash/bucket_memory.go
@@ -17,10 +17,9 @@ type MemoryBucket struct {
 }
 
 func (b *MemoryBucket) Record(metadata fs.Metadata, contentHash []byte) {
-	if metadata.Typeflag == tar.TypeDir {
-		if !strings.HasSuffix(metadata.Name, "/") {
-			metadata.Name += "/"
-		}
+	normalized := Normalize(metadata.Name, metadata.Typeflag == tar.TypeDir)
+	if metadata.Name != normalized {
+		panic(InvalidParameter.New("bucket: non-normalized path: %q (normal: %q)", metadata.Name, normalized))
 	}
 	b.lines = append(b.lines, Record{metadata, contentHash})
 }

--- a/lib/fshash/bucket_memory.go
+++ b/lib/fshash/bucket_memory.go
@@ -35,6 +35,10 @@ func (b *MemoryBucket) Iterator() RecordIterator {
 	return &memoryBucketIterator{b.lines, 0, &that}
 }
 
+func (b *MemoryBucket) Length() int {
+	return len(b.lines)
+}
+
 type memoryBucketIterator struct {
 	lines []Record
 	this  int  // pretending a linear structure is a tree is weird.

--- a/lib/fshash/fs_walk_test.go
+++ b/lib/fshash/fs_walk_test.go
@@ -33,9 +33,9 @@ func Test(t *testing.T) {
 				Convey("Then the bucket contains the file descriptions", func() {
 					So(len(bucket.lines), ShouldEqual, 5)
 					sort.Sort(linesByFilepath(bucket.lines))
-					So(bucket.lines[0].Metadata.Name, ShouldEqual, ".")
-					So(bucket.lines[1].Metadata.Name, ShouldEqual, "./a")
-					So(bucket.lines[2].Metadata.Name, ShouldEqual, "./b")
+					So(bucket.lines[0].Metadata.Name, ShouldEqual, "./")
+					So(bucket.lines[1].Metadata.Name, ShouldEqual, "./a/")
+					So(bucket.lines[2].Metadata.Name, ShouldEqual, "./b/")
 					So(bucket.lines[3].Metadata.Name, ShouldEqual, "./b/c")
 					So(bucket.lines[4].Metadata.Name, ShouldEqual, "./d")
 				})
@@ -55,12 +55,12 @@ func Test(t *testing.T) {
 
 				Convey("We can walk the bucket and touch all records", func() {
 					root := bucket.Iterator()
-					So(root.Record().Metadata.Name, ShouldEqual, ".")
+					So(root.Record().Metadata.Name, ShouldEqual, "./")
 					node_a := root.NextChild().(RecordIterator)
-					So(node_a.Record().Metadata.Name, ShouldEqual, "./a")
+					So(node_a.Record().Metadata.Name, ShouldEqual, "./a/")
 					So(node_a.NextChild(), ShouldBeNil)
 					node_b := root.NextChild().(RecordIterator)
-					So(node_b.Record().Metadata.Name, ShouldEqual, "./b")
+					So(node_b.Record().Metadata.Name, ShouldEqual, "./b/")
 					node_c := node_b.NextChild().(RecordIterator)
 					So(node_c.Record().Metadata.Name, ShouldEqual, "./b/c")
 					So(node_c.NextChild(), ShouldBeNil)

--- a/lib/integration/basic.json
+++ b/lib/integration/basic.json
@@ -3,6 +3,7 @@
 		{
 			"Type": "tar",
 			"Location": "/",
+			"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
 			"URI": "assets/ubuntu.tar.gz"
 		}
 	],

--- a/lib/integration/runAll.sh
+++ b/lib/integration/runAll.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Run each integration example; useful for CI
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$DIR"/../..
+
+for formula in `ls -1 lib/integration/*.json`; do
+    echo $formula
+    time ./goad exec run -i $formula
+    echo
+done

--- a/lib/integration/unknown.json
+++ b/lib/integration/unknown.json
@@ -1,0 +1,19 @@
+{
+    "Inputs": [
+        {
+            "Type": "exec-tar",
+            "Location": "/",
+            "URI": "assets/ubuntu.tar.gz"
+        }
+    ],
+    "Accents": {
+        "Entrypoint": [ "echo", "Hello from repeatr!" ]
+    },
+    "Outputs": [
+        {
+            "Type": "tar",
+            "Location": "/var/log",
+            "URI": "basic.tar"
+        }
+    ]
+}

--- a/lib/integration/wait.json
+++ b/lib/integration/wait.json
@@ -3,6 +3,7 @@
 		{
 			"Type": "tar",
 			"Location": "/",
+			"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
 			"URI": "assets/ubuntu.tar.gz"
 		}
 	],

--- a/lib/treewalk/walk.go
+++ b/lib/treewalk/walk.go
@@ -27,12 +27,14 @@ var SkipNode = errors.New("skip this node")
 	(and probably should, to reduce memory use on large trees).
 */
 func Walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
-	err := preVisit(node)
-	if err != nil {
-		if err == SkipNode {
-			return nil
+	if preVisit != nil {
+		err := preVisit(node)
+		if err != nil {
+			if err == SkipNode {
+				return nil
+			}
+			return err
 		}
-		return err
 	}
 
 	for next := node.NextChild(); next != nil; next = node.NextChild() {
@@ -41,12 +43,14 @@ func Walk(node Node, preVisit WalkFunc, postVisit WalkFunc) error {
 		}
 	}
 
-	err = postVisit(node)
-	if err != nil {
-		if err == SkipNode {
-			return nil
+	if postVisit != nil {
+		err := postVisit(node)
+		if err != nil {
+			if err == SkipNode {
+				return nil
+			}
+			return err
 		}
-		return err
 	}
 
 	return nil

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -7,6 +7,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"time"
 
 	"github.com/spacemonkeygo/errors"
 	"github.com/spacemonkeygo/errors/try"
@@ -78,6 +79,10 @@ func walk(srcBasePath string, tw *tar.Writer, bucket fshash.Bucket, hasherFactor
 			return filenode.Err
 		}
 		hdr, file := fs.ScanFile(srcBasePath, filenode.Path, filenode.Info)
+		// flaten time to seconds.  this tar writer impl doesn't do subsecond precision.
+		// the writer will flatten it internally of course, but we need to do it here as well
+		// so that the hash and the serial form are describing the same thing.
+		hdr.ModTime = hdr.ModTime.Truncate(time.Second)
 		wat := tar.Header(hdr) // this line is... we're not gonna talk about this.
 		tw.WriteHeader(&wat)
 		if file == nil {

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -48,7 +48,7 @@ func TestTarCompat(t *testing.T) {
 				// boy, that's entertaining though: gnu tar does all the same stuff,
 				// except it doesn't honor our nanosecond timings.
 				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareMtime
-				So(rescan.Describe(comparisonLevel), ShouldResemble, fixture.Describe(comparisonLevel))
+				So(rescan.Describe(comparisonLevel), ShouldEqual, fixture.Describe(comparisonLevel))
 			}))
 		}
 	})

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -47,7 +47,7 @@ func TestTarCompat(t *testing.T) {
 				rescan := filefixture.Scan("./untar")
 				// boy, that's entertaining though: gnu tar does all the same stuff,
 				// except it doesn't honor our nanosecond timings.
-				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareMtime
+				comparisonLevel := filefixture.CompareDefaults &^ filefixture.CompareSubsecond
 				So(rescan.Describe(comparisonLevel), ShouldEqual, fixture.Describe(comparisonLevel))
 			}))
 		}

--- a/testutil/filefixture/file_fixtures.go
+++ b/testutil/filefixture/file_fixtures.go
@@ -11,6 +11,11 @@ import (
 	"polydawn.net/repeatr/lib/fs"
 )
 
+// TODO -- we need to segment these fixtures even MORE by minimum features.
+// - BaseDirNonEpochMtime -- optional to support (not all tar inputs datum will!)
+// - filesystems that differ only by modtime -- use these for the hash uniqueness subtable
+
+// slightly varied structure.  empty dirs; maxdepth=2.
 var Alpha Fixture = Fixture{"Alpha",
 	[]FixtureFile{
 		{fs.Metadata{Name: ".", Mode: 0755, ModTime: time.Unix(1000, 2000)}, nil},
@@ -20,6 +25,7 @@ var Alpha Fixture = Fixture{"Alpha",
 	},
 }.defaults()
 
+// flat structure.  all files.  convenient for checking mounts work with plain 'ls' output.
 var Beta Fixture = Fixture{"Beta",
 	[]FixtureFile{
 		{fs.Metadata{Name: "."}, nil},
@@ -29,6 +35,7 @@ var Beta Fixture = Fixture{"Beta",
 	},
 }.defaults()
 
+// describes a file where part of the path to it contains a symlink.  should be rejected by sane systems.
 var Breakout Fixture = Fixture{"Breakout",
 	[]FixtureFile{
 		{fs.Metadata{Name: "."}, nil},
@@ -38,7 +45,27 @@ var Breakout Fixture = Fixture{"Breakout",
 	},
 }.defaults() // this is *not* included in `All` because it's actually a little scary.
 
+// deep and varied structures.  files and dirs.
+// subtle: a dir with a sibling that's a suffix of its name (can trip up dir/child adjacency sorting).
+// subtle: a file with a sibling that's a suffix of its name (other half of the test, to make sure the prefix doesn't create an incorect tree node).
+var Gamma Fixture = Fixture{"Gamma",
+	[]FixtureFile{
+		{fs.Metadata{Name: "."}, nil},
+		{fs.Metadata{Name: "./etc"}, nil},
+		{fs.Metadata{Name: "./etc/init.d/"}, nil},
+		{fs.Metadata{Name: "./etc/init.d/service-p"}, []byte("p!")},
+		{fs.Metadata{Name: "./etc/init.d/service-q"}, []byte("q!")},
+		{fs.Metadata{Name: "./etc/init/"}, nil},
+		{fs.Metadata{Name: "./etc/init/zed"}, []byte("grue")},
+		{fs.Metadata{Name: "./etc/trick"}, []byte("sib")},
+		{fs.Metadata{Name: "./etc/tricky"}, []byte("sob")},
+		{fs.Metadata{Name: "./var"}, nil},
+		{fs.Metadata{Name: "./var/fun"}, []byte("zyx")},
+	},
+}.defaults()
+
 var All []Fixture = []Fixture{
 	Alpha,
 	Beta,
+	Gamma,
 }

--- a/testutil/filefixture/types.go
+++ b/testutil/filefixture/types.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/lib/fs"
 )
 
@@ -83,10 +83,10 @@ func defaults(f FixtureFile) FixtureFile {
 		f.Metadata.Gid = 10000
 	}
 	if f.Metadata.ModTime.IsZero() {
-		f.Metadata.ModTime = time.Unix(0, 0).UTC()
+		f.Metadata.ModTime = def.Epochwhen
 	}
 	if f.Metadata.AccessTime.IsZero() {
-		f.Metadata.AccessTime = time.Unix(0, 0).UTC()
+		f.Metadata.AccessTime = def.Epochwhen
 	}
 	return f
 }

--- a/testutil/filefixture/types.go
+++ b/testutil/filefixture/types.go
@@ -65,6 +65,12 @@ func defaults(f FixtureFile) FixtureFile {
 			f.Metadata.Typeflag = tar.TypeReg
 		}
 	}
+	switch f.Metadata.Typeflag {
+	case tar.TypeDir:
+		if !strings.HasSuffix(f.Metadata.Name, "/") {
+			f.Metadata.Name += "/"
+		}
+	}
 	if f.Metadata.Mode == 0 {
 		switch f.Metadata.Typeflag {
 		case tar.TypeDir:

--- a/testutil/requirements.go
+++ b/testutil/requirements.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"os"
+	"testing"
 
 	"github.com/smartystreets/goconvey/convey"
 )
@@ -27,6 +28,14 @@ func Convey_IfCanNS(items ...interface{}) {
 	case os.Getenv("TRAVIS") != "":
 		convey.SkipConvey(items...)
 	default:
+		convey.Convey(items...)
+	}
+}
+
+func Convey_IfSlowTests(items ...interface{}) {
+	if testing.Short() {
+		convey.SkipConvey(items...)
+	} else {
 		convey.Convey(items...)
 	}
 }


### PR DESCRIPTION
Hashing tar inputs!

This implementation of pure golang tar parsing can produce a precise and consistent hash, and tests cleanly on our ubuntu tarball fixture, complete will device nodes, timestamps, uids, etc etc etc... with results exactly matching what we get out of an exec to gnu tar.