### PR TITLE
S3 IO

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule ".gopath/src/github.com/polydawn/gosh"]
 	path = .gopath/src/github.com/polydawn/gosh
 	url = https://github.com/polydawn/gosh.git
+[submodule ".gopath/src/github.com/rlmcpherson/s3gof3r"]
+	path = .gopath/src/github.com/rlmcpherson/s3gof3r
+	url = https://github.com/rlmcpherson/s3gof3r.git

--- a/input/errors.go
+++ b/input/errors.go
@@ -7,6 +7,11 @@ import (
 var Error *errors.ErrorClass = errors.NewClass("InputError") // grouping, do not instantiate
 
 /*
+	Raised to indicate that some configuration is missing or malformed.
+*/
+var ConfigError *errors.ErrorClass = Error.NewClass("InputConfigError")
+
+/*
 	Indicates that an error getting the data an input described.
 	(As contrasted with a `TargetFilesystemUnavailableError`, which is
 	an error that comes while trying to unpack the data source onto a

--- a/input/s3/errors.go
+++ b/input/s3/errors.go
@@ -1,0 +1,16 @@
+package s3
+
+import (
+	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/input"
+)
+
+/*
+	Raised if S3 credentials are not available.
+*/
+var S3CredentialsMissingError *errors.ErrorClass = input.ConfigError.NewClass("InputS3CredentialsMissingError")
+
+/*
+	Grouping for an error encountered while talking to the S3 API.
+*/
+var S3Error *errors.ErrorClass = input.Error.NewClass("InputS3Error")

--- a/input/s3/s3_input.go
+++ b/input/s3/s3_input.go
@@ -1,0 +1,1 @@
+package s3

--- a/input/s3/s3_input.go
+++ b/input/s3/s3_input.go
@@ -1,1 +1,133 @@
 package s3
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
+	"hash"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"time"
+
+	"github.com/rlmcpherson/s3gof3r"
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/input"
+	"polydawn.net/repeatr/input/tar2"
+	"polydawn.net/repeatr/lib/fshash"
+)
+
+const Type = "s3"
+
+var _ input.Input = &Input{} // interface assertion
+
+type Input struct {
+	spec          def.Input
+	hasherFactory func() hash.Hash
+}
+
+func New(spec def.Input) input.Input {
+	if spec.Type != Type {
+		panic(errors.ProgrammerError.New("This input implementation supports definitions of type %q, not %q", Type, spec.Type))
+	}
+	return &Input{
+		spec:          spec,
+		hasherFactory: sha512.New384,
+	}
+}
+
+func (i Input) Apply(destinationRoot string) <-chan error {
+	done := make(chan error)
+	go func() {
+		defer close(done)
+		try.Do(func() {
+			// do make a dir for untaring into.
+			// tars may specify permission and time bits for their top dir, but if not, we'll start with sane defaults.
+			err := os.MkdirAll(destinationRoot, 0755)
+			if err != nil {
+				panic(input.TargetFilesystemUnavailableIOError(err))
+			}
+
+			// parse URI
+			u, err := url.Parse(i.spec.URI)
+			if err != nil {
+				panic(input.ConfigError.New("failed to parse URI: %s", err))
+			}
+			bucketName := u.Host
+			storePath := u.Path
+			var splay bool
+			switch u.Scheme {
+			case "s3":
+				splay = false
+			case "s3+splay":
+				splay = true
+			default:
+				panic(input.ConfigError.New("unrecognized scheme: %q", u.Scheme))
+			}
+
+			// load keys from env
+			// TODO someday URIs should grow smart enough to control this in a more general fashion -- but for now, host ENV is actually pretty feasible and plays easily with others.
+			keys, err := s3gof3r.EnvKeys()
+			if err != nil {
+				panic(S3CredentialsMissingError.Wrap(err))
+			}
+
+			// initialize reader from s3!
+			getPath := storePath
+			if splay {
+				getPath = path.Join(storePath, i.spec.Hash)
+			}
+			s3reader := makeS3reader(bucketName, getPath, keys)
+			defer s3reader.Close()
+
+			// prepare decompression as necessary
+			reader, err := tar2.Decompress(s3reader)
+			if err != nil {
+				panic(input.DataSourceUnavailableError.New("could not start decompressing: %s", err))
+			}
+			tarReader := tar.NewReader(reader)
+
+			// unroll the tar, copying and accumulating data for integrity check
+			bucket := &fshash.MemoryBucket{}
+			tar2.Extract(tarReader, destinationRoot, bucket, i.hasherFactory)
+
+			// hash whole tree
+			actualTreeHash, _ := fshash.Hash(bucket, i.hasherFactory)
+
+			// verify total integrity
+			expectedTreeHash, err := base64.URLEncoding.DecodeString(i.spec.Hash)
+			if !bytes.Equal(actualTreeHash, expectedTreeHash) {
+				done <- input.InputHashMismatchError.New("expected hash %q, got %q", i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
+			}
+		}).Catch(input.Error, func(err *errors.Error) {
+			done <- err
+		}).CatchAll(func(err error) {
+			// All errors we emit will be under `input.Error`'s type.
+			// Every time we hit this UnknownError path, we should consider it a bug until that error is categorized.
+			done <- input.UnknownError.Wrap(err).(*errors.Error)
+		}).Done()
+	}()
+	return done
+}
+
+var s3Conf = &s3gof3r.Config{
+	Concurrency: 10,
+	PartSize:    20 * 1024 * 1024,
+	NTry:        10,
+	Md5Check:    false,
+	Scheme:      "https",
+	Client:      s3gof3r.ClientWithTimeout(15 * time.Second),
+}
+
+func makeS3reader(bucketName string, path string, keys s3gof3r.Keys) io.ReadCloser {
+	s3 := s3gof3r.New("s3.amazonaws.com", keys)
+	w, _, err := s3.Bucket(bucketName).GetReader(path, s3Conf)
+	if err != nil {
+		panic(S3Error.Wrap(err))
+	}
+	return w
+}

--- a/input/s3/s3_input_test.go
+++ b/input/s3/s3_input_test.go
@@ -1,0 +1,21 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/rlmcpherson/s3gof3r"
+	"polydawn.net/repeatr/input/tests"
+	"polydawn.net/repeatr/lib/guid"
+	"polydawn.net/repeatr/output/s3"
+)
+
+func TestCoreCompliance(t *testing.T) {
+	if _, err := s3gof3r.EnvKeys(); err != nil {
+		t.Skipf("skipping s3 output tests; no s3 credentials loaded (err: %s)", err)
+	}
+
+	// group all effects of this test run under one "dir" for human reader sanity and cleanup in extremis.
+	testRunGuid := guid.New()
+
+	tests.CheckRoundTrip(t, "s3", s3.New, New, "s3://repeatr-test/test-"+testRunGuid+"/rt/obj.tar")
+}

--- a/input/s3/s3_input_test.go
+++ b/input/s3/s3_input_test.go
@@ -18,4 +18,5 @@ func TestCoreCompliance(t *testing.T) {
 	testRunGuid := guid.New()
 
 	tests.CheckRoundTrip(t, "s3", s3.New, New, "s3://repeatr-test/test-"+testRunGuid+"/rt/obj.tar")
+	tests.CheckRoundTrip(t, "s3", s3.New, New, "s3+splay://repeatr-test/test-"+testRunGuid+"/rt-splay/heap/")
 }

--- a/input/s3/s3_input_tests.go
+++ b/input/s3/s3_input_tests.go
@@ -1,0 +1,1 @@
+package s3

--- a/input/s3/s3_input_tests.go
+++ b/input/s3/s3_input_tests.go
@@ -1,1 +1,0 @@
-package s3

--- a/input/tar2/tar_input.go
+++ b/input/tar2/tar_input.go
@@ -72,7 +72,7 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 
 			// unroll the tar, copying and accumulating data for integrity check
 			bucket := &fshash.MemoryBucket{}
-			walk(tarReader, destinationRoot, bucket, i.hasherFactory)
+			Extract(tarReader, destinationRoot, bucket, i.hasherFactory)
 
 			// hash whole tree
 			actualTreeHash, _ := fshash.Hash(bucket, i.hasherFactory)
@@ -93,7 +93,7 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 	return done
 }
 
-func walk(tr *tar.Reader, destBasePath string, bucket fshash.Bucket, hasherFactory func() hash.Hash) error {
+func Extract(tr *tar.Reader, destBasePath string, bucket fshash.Bucket, hasherFactory func() hash.Hash) error {
 	for {
 		thdr, err := tr.Next()
 		if err == io.EOF {

--- a/input/tar2/tar_input_test.go
+++ b/input/tar2/tar_input_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestCoreCompliance(t *testing.T) {
-	tests.CheckRoundTrip(t, "tar", tar2.New, New)
+	tests.CheckRoundTrip(t, "tar", tar2.New, New, "./output.dump.tar")
 }
 
 const ubuntuTarballHash = "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v"

--- a/input/tests/input_tests.go
+++ b/input/tests/input_tests.go
@@ -28,7 +28,7 @@ type OutputFactory func(def.Output) output.Output
 	- Places it in a new filesystem with the input system and the scanned hash
 	- Checks the new filesystem matches the original
 */
-func CheckRoundTrip(t *testing.T, kind string, newOutput OutputFactory, newInput InputFactory) {
+func CheckRoundTrip(t *testing.T, kind string, newOutput OutputFactory, newInput InputFactory, bounceURI string) {
 	Convey("Scanning and replacing a filesystem should agree on hash and content", t,
 		testutil.Requires(testutil.RequiresRoot, func() {
 			for _, fixture := range filefixture.All {
@@ -39,7 +39,7 @@ func CheckRoundTrip(t *testing.T, kind string, newOutput OutputFactory, newInput
 					// scan with output
 					scanner := newOutput((def.Output{
 						Type: kind,
-						URI:  "./output.dump",
+						URI:  bounceURI,
 					}))
 					report := <-scanner.Apply("./fixture")
 					So(report.Err, ShouldBeNil)
@@ -48,7 +48,7 @@ func CheckRoundTrip(t *testing.T, kind string, newOutput OutputFactory, newInput
 					input := newInput((def.Input{
 						Type: kind,
 						Hash: report.Output.Hash,
-						URI:  "./output.dump",
+						URI:  bounceURI,
 					}))
 					err := <-input.Apply("./unpack")
 					So(err, ShouldBeNil)

--- a/output/dir/dir_output_test.go
+++ b/output/dir/dir_output_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestCoreCompliance(t *testing.T) {
-	tests.CheckScanWithoutMutation(t, "dir", New)
-	tests.CheckScanProducesConsistentHash(t, "dir", New)
-	tests.CheckScanProducesDistinctHashes(t, "dir", New)
+	tests.CheckScanWithoutMutation(t, "dir", New, "./output.dump")
+	tests.CheckScanProducesConsistentHash(t, "dir", New, "./output.dump")
+	tests.CheckScanProducesDistinctHashes(t, "dir", New, "./output.dump")
 }

--- a/output/errors.go
+++ b/output/errors.go
@@ -7,6 +7,11 @@ import (
 var Error *errors.ErrorClass = errors.NewClass("OutputError") // grouping, do not instantiate
 
 /*
+	Raised to indicate that some configuration is missing or malformed.
+*/
+var ConfigError *errors.ErrorClass = Error.NewClass("OutputConfigError")
+
+/*
 	Indicates that the target filesystem (the one given to `Apply`) had some error.
 */
 var TargetFilesystemUnavailableError *errors.ErrorClass = Error.NewClass("OutputTargetFilesystemUnavailableError")

--- a/output/s3/doc.go
+++ b/output/s3/doc.go
@@ -1,0 +1,45 @@
+/*
+	Data warehousing backed by Amazon S3.
+
+	This transport uses tars as the metaphor for mapping filesystems onto S3.
+	Amazon S3 is a key-value store at heart, and (despite what some of the web
+	UI may seem to suggest)	requires more bits for file attributes, etc to manifest as a filesystem.
+	Using tarballs gives us a place to preserve file metadata in a widely-understood way.
+	(Note that this is not the only possible approach; other transports may
+	use S3 as a data warehouse, but map it to filesystems differently.)
+
+	Silo URIs must parse as URIs and have one of two schemes: "s3://" or "s3+splay://".
+
+	The "s3+splay://" scheme will store data in content-addressable names
+	where the S3 bucket is the host component of the URI, and the path component
+	of the URI is used as a prefix to the full data path.
+	In this configuration, the transport is compliant with the usual expectation
+	that the same location string can be used for as a prefix for as much data
+	as you want, and it will Do The Right Thing, and also automatically deduplicate.
+
+	The "s3://" scheme store data at URI location literally and without
+	content-addressible properties; be advised that in this configuration, the
+	transport will *NOT* be compliant with the usual expectation that more
+	than one piece of data may be stored at the same silo URI.
+
+	Login secrets configuration is handled through environment variables:
+	`AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY`.
+
+	Setup and management of S3/AWS permissions models are *not* handled by this system --
+	Those are arcana that should be managed by your organization, not repeatr.
+
+	Note that S3/AWS permissions are complicated; and be advised that in many configurations,
+	accounts may be able to write data which they then instantly lose permission to
+	manage or even read back; this will result in permission denied errors from this
+	system, and may result in dirty state left behind (because we lack permission
+	to clean it up, and cannot discover this until it's too late!).
+	PRs for improving this behavior deeply welcome; this author is not an S3/AWS/IAM professional.
+
+	If you're just getting started with S3/AWS permissions, try the docs here:
+	https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html
+	These describe attaching policies to a bucket that can grant permissions to a user account.
+
+	This IO system happens to share the same hash-space as the Tar IO system,
+	and may thus safely share a cache with Tar IO systems.
+*/
+package s3

--- a/output/s3/errors.go
+++ b/output/s3/errors.go
@@ -1,0 +1,16 @@
+package s3
+
+import (
+	"github.com/spacemonkeygo/errors"
+	"polydawn.net/repeatr/output"
+)
+
+/*
+	Raised if S3 credentials are not available.
+*/
+var S3ConfigurationMissingError *errors.ErrorClass = output.Error.NewClass("OutputS3ConfigurationMissingError")
+
+/*
+	Grouping for an error encountered while talking to the S3 API.
+*/
+var S3Error *errors.ErrorClass = output.Error.NewClass("OutputS3Error")

--- a/output/s3/errors.go
+++ b/output/s3/errors.go
@@ -8,7 +8,7 @@ import (
 /*
 	Raised if S3 credentials are not available.
 */
-var S3ConfigurationMissingError *errors.ErrorClass = output.Error.NewClass("OutputS3ConfigurationMissingError")
+var S3CredentialsMissingError *errors.ErrorClass = output.ConfigError.NewClass("OutputS3CredentialsMissingError")
 
 /*
 	Grouping for an error encountered while talking to the S3 API.

--- a/output/s3/s3_output.go
+++ b/output/s3/s3_output.go
@@ -1,0 +1,1 @@
+package s3

--- a/output/s3/s3_output.go
+++ b/output/s3/s3_output.go
@@ -1,15 +1,23 @@
 package s3
 
 import (
+	"bytes"
 	"crypto/sha512"
+	"encoding/xml"
+	"fmt"
 	"hash"
 	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/rlmcpherson/s3gof3r"
 	"github.com/spacemonkeygo/errors"
 	"github.com/spacemonkeygo/errors/try"
 	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/output"
 	"polydawn.net/repeatr/output/tar2"
 )
@@ -25,6 +33,17 @@ var _ output.Output = &Output{} // interface assertion
 
 	This IO system happens to share the same hash-space as the Tar IO system,
 	and may thus safely share a cache with Tar IO systems.
+
+	Working with S3 permissions: good luck; be advised that in many configurations,
+	accounts may be able to write data which they then instantly lose permission to
+	manage or even read back; this will result in permission denied errors from this
+	system, and may result in dirty state left behind (because we have to permission
+	to clean it up once we've created this, and cannot discover this until it's
+	too late!).  PRs for improving this behavior deeply welcome; this author
+	is not an S3/AWS/IAM professional.
+
+	Try the docs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html --
+	these describe attaching policies to a bucket that can grant permissions to a user account.
 */
 type Output struct {
 	spec          def.Output
@@ -50,26 +69,56 @@ func (o Output) Apply(basePath string) <-chan output.Report {
 		defer close(done)
 		try.Do(func() {
 			// parse URI
-			// TODO
-			bucketName := "repeatr-test"
-			storePath := "keks"
+			u, err := url.Parse(o.spec.URI)
+			if err != nil {
+				panic(output.ConfigError.New("failed to parse URI: %s", err))
+			}
+			bucketName := u.Host
+			storePath := u.Path
+			var splay bool
+			switch u.Scheme {
+			case "s3":
+				splay = false
+			case "s3+splay":
+				splay = true
+			default:
+				panic(output.ConfigError.New("unrecognized scheme: %q", u.Scheme))
+			}
 
 			// load keys from env
 			// TODO someday URIs should grow smart enough to control this in a more general fashion -- but for now, host ENV is actually pretty feasible and plays easily with others.
 			keys, err := s3gof3r.EnvKeys()
 			if err != nil {
-				panic(S3ConfigurationMissingError.Wrap(err))
+				panic(S3CredentialsMissingError.Wrap(err))
 			}
 
 			// initialize writer to s3!
-			s3writer := makeS3writer(bucketName, storePath, keys)
-			defer s3writer.Close()
+			// if the URI indicated splay behavior, first stream data to {$bucketName}:{dirname($storePath)}/.tmp.upload.{basename($storePath)}.{random()};
+			// this allows us to start uploading before the final hash is determined and relocate it later.
+			// for direct paths, upload into place, because aws already manages atomicity at that scale (and they don't have a rename or copy operation that's free, because uh...?  no time to implement it since 2006, apparently).
+			putPath := storePath
+			if splay {
+				putPath = path.Join(path.Dir(storePath), ".tmp.upload."+path.Base(storePath)+"."+guid.New())
+			}
+			s3writer := makeS3writer(bucketName, putPath, keys)
 
 			// walk, fwrite, hash
 			o.spec.Hash = tar2.Save(s3writer, basePath, o.hasherFactory)
 
-			// TODO
-			// if the URI indicated splay behavior, do a rename from the upload location to final CA resting place.
+			// flush and check errors on the final write to s3.
+			// be advised that this close method does *a lot* of work aside from connection termination.
+			// also calling it twice causes the library to wigg out and delete things, i don't even.
+			err = s3writer.Close()
+			if err != nil {
+				panic(S3Error.Wrap(err))
+			}
+
+			// if the URI indicated splay behavior, rename the temp filepath to the real one;
+			// the upload location is suffixed to make a CA resting place.
+			if splay {
+				finalPath := path.Join(storePath, o.spec.Hash)
+				reloc(bucketName, putPath, finalPath, keys)
+			}
 
 			done <- output.Report{nil, o.spec}
 		}).Catch(output.Error, func(err *errors.Error) {
@@ -82,20 +131,60 @@ func (o Output) Apply(basePath string) <-chan output.Report {
 	return done
 }
 
+var s3Conf = &s3gof3r.Config{
+	Concurrency: 10,
+	PartSize:    20 * 1024 * 1024,
+	NTry:        10,
+	Md5Check:    false,
+	Scheme:      "https",
+	Client:      s3gof3r.ClientWithTimeout(15 * time.Second),
+}
+
 func makeS3writer(bucketName string, path string, keys s3gof3r.Keys) io.WriteCloser {
-	conf := &s3gof3r.Config{
-		Concurrency: 10,
-		PartSize:    20 * 1024 * 1024,
-		NTry:        10,
-		Md5Check:    false,
-		Scheme:      "https",
-		Client:      s3gof3r.ClientWithTimeout(5 * time.Second),
-	}
 	s3 := s3gof3r.New("s3.amazonaws.com", keys)
-	bucket := s3.Bucket(bucketName)
-	w, err := bucket.PutWriter(path, nil, conf)
+	w, err := s3.Bucket(bucketName).PutWriter(path, nil, s3Conf)
 	if err != nil {
 		panic(S3Error.Wrap(err))
 	}
 	return w
+}
+
+func reloc(bucketName, oldPath, newPath string, keys s3gof3r.Keys) {
+	s3 := s3gof3r.New("s3.amazonaws.com", keys)
+	bucket := s3.Bucket(bucketName)
+	// this is a POST at the bottom, and copies are a PUT.  whee.
+	//w, err := s3.Bucket(bucketName).PutWriter(newPath, copyInstruction, s3Conf)
+	// So, implement our own aws copy API.
+	req, err := http.NewRequest("PUT", "", &bytes.Buffer{})
+	if err != nil {
+		panic(S3Error.Wrap(err))
+	}
+	req.URL.Scheme = s3Conf.Scheme
+	req.URL.Host = fmt.Sprintf("%s.%s", bucketName, s3.Domain)
+	req.URL.Path = path.Clean(fmt.Sprintf("/%s", newPath))
+	// Communicate the copy source object with a header.
+	// Be advised that if this object doesn't exist, amazon reports that as a 404... yes, a 404 that has nothing to do with the query URI.
+	req.Header.Add("x-amz-copy-source", path.Join("/", bucketName, oldPath))
+	bucket.Sign(req)
+	resp, err := s3Conf.Client.Do(req)
+	if err != nil {
+		panic(S3Error.Wrap(err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		panic(S3Error.Wrap(newRespError(resp)))
+	}
+	// delete previous location
+	if err := bucket.Delete(oldPath); err != nil {
+		panic(S3Error.Wrap(err))
+	}
+}
+
+func newRespError(r *http.Response) *s3gof3r.RespError {
+	e := new(s3gof3r.RespError)
+	e.StatusCode = r.StatusCode
+	b, _ := ioutil.ReadAll(r.Body)
+	xml.NewDecoder(bytes.NewReader(b)).Decode(e) // parse error from response
+	r.Body.Close()
+	return e
 }

--- a/output/s3/s3_output.go
+++ b/output/s3/s3_output.go
@@ -1,1 +1,101 @@
 package s3
+
+import (
+	"crypto/sha512"
+	"hash"
+	"io"
+	"time"
+
+	"github.com/rlmcpherson/s3gof3r"
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/output"
+	"polydawn.net/repeatr/output/tar2"
+)
+
+const Type = "s3"
+
+var _ output.Output = &Output{} // interface assertion
+
+/*
+	Amazon S3 silos are used by this transport in a very MVP-oriented way:
+	tarballs streamed in and out, because we know how to preserve file
+	attributes in a widely-understood way by doing this.
+
+	This IO system happens to share the same hash-space as the Tar IO system,
+	and may thus safely share a cache with Tar IO systems.
+*/
+type Output struct {
+	spec          def.Output
+	hasherFactory func() hash.Hash
+}
+
+func New(spec def.Output) output.Output {
+	if spec.Type != Type {
+		panic(errors.ProgrammerError.New("This output implementation supports definitions of type %q, not %q", Type, spec.Type))
+	}
+	return &Output{
+		spec:          spec,
+		hasherFactory: sha512.New384,
+	}
+}
+
+func (o Output) Apply(basePath string) <-chan output.Report {
+	// We actually shell out to the entire streaming part of the tar system.
+	// All the formatting and hashing is identical; this just shoves the
+	//  stream to a S3 bucket instead of a local filesystem.
+	done := make(chan output.Report)
+	go func() {
+		defer close(done)
+		try.Do(func() {
+			// parse URI
+			// TODO
+			bucketName := "repeatr-test"
+			storePath := "keks"
+
+			// load keys from env
+			// TODO someday URIs should grow smart enough to control this in a more general fashion -- but for now, host ENV is actually pretty feasible and plays easily with others.
+			keys, err := s3gof3r.EnvKeys()
+			if err != nil {
+				panic(S3ConfigurationMissingError.Wrap(err))
+			}
+
+			// initialize writer to s3!
+			s3writer := makeS3writer(bucketName, storePath, keys)
+			defer s3writer.Close()
+
+			// walk, fwrite, hash
+			o.spec.Hash = tar2.Save(s3writer, basePath, o.hasherFactory)
+
+			// TODO
+			// if the URI indicated splay behavior, do a rename from the upload location to final CA resting place.
+
+			done <- output.Report{nil, o.spec}
+		}).Catch(output.Error, func(err *errors.Error) {
+			done <- output.Report{err, o.spec}
+		}).CatchAll(func(err error) {
+			// All errors we emit will be under `output.Error`'s type.
+			done <- output.Report{output.UnknownError.Wrap(err).(*errors.Error), o.spec}
+		}).Done()
+	}()
+	return done
+}
+
+func makeS3writer(bucketName string, path string, keys s3gof3r.Keys) io.WriteCloser {
+	conf := &s3gof3r.Config{
+		Concurrency: 10,
+		PartSize:    20 * 1024 * 1024,
+		NTry:        10,
+		Md5Check:    false,
+		Scheme:      "https",
+		Client:      s3gof3r.ClientWithTimeout(5 * time.Second),
+	}
+	s3 := s3gof3r.New("s3.amazonaws.com", keys)
+	bucket := s3.Bucket(bucketName)
+	w, err := bucket.PutWriter(path, nil, conf)
+	if err != nil {
+		panic(S3Error.Wrap(err))
+	}
+	return w
+}

--- a/output/s3/s3_output.go
+++ b/output/s3/s3_output.go
@@ -26,25 +26,6 @@ const Type = "s3"
 
 var _ output.Output = &Output{} // interface assertion
 
-/*
-	Amazon S3 silos are used by this transport in a very MVP-oriented way:
-	tarballs streamed in and out, because we know how to preserve file
-	attributes in a widely-understood way by doing this.
-
-	This IO system happens to share the same hash-space as the Tar IO system,
-	and may thus safely share a cache with Tar IO systems.
-
-	Working with S3 permissions: good luck; be advised that in many configurations,
-	accounts may be able to write data which they then instantly lose permission to
-	manage or even read back; this will result in permission denied errors from this
-	system, and may result in dirty state left behind (because we have to permission
-	to clean it up once we've created this, and cannot discover this until it's
-	too late!).  PRs for improving this behavior deeply welcome; this author
-	is not an S3/AWS/IAM professional.
-
-	Try the docs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html --
-	these describe attaching policies to a bucket that can grant permissions to a user account.
-*/
 type Output struct {
 	spec          def.Output
 	hasherFactory func() hash.Hash

--- a/output/s3/s3_output_test.go
+++ b/output/s3/s3_output_test.go
@@ -1,0 +1,1 @@
+package s3

--- a/output/s3/s3_output_test.go
+++ b/output/s3/s3_output_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/rlmcpherson/s3gof3r"
+	"polydawn.net/repeatr/lib/guid"
 	"polydawn.net/repeatr/output/tests"
 )
 
@@ -15,13 +16,15 @@ func TestCoreCompliance(t *testing.T) {
 	// FIXME: do a cleanup pass on these shared test things...
 	//   - they shouldn't be doing requirements (like ifHaveRoot) internally; that's caller's choice.
 	//   - they shouldn't be taking `t`, because that limits composability.
-	//   - looks like we're gonna need to be able to supply the URI to bounce to, as well.
 
 	if _, err := s3gof3r.EnvKeys(); err != nil {
 		t.Skipf("skipping s3 output tests; no s3 credentials loaded (err: %s)", err)
 	}
 
-	tests.CheckScanWithoutMutation(t, "s3", New)
-	tests.CheckScanProducesConsistentHash(t, "s3", New)
-	tests.CheckScanProducesDistinctHashes(t, "s3", New)
+	// group all effects of this test run under one "dir" for human reader sanity and cleanup in extremis.
+	testRunGuid := guid.New()
+
+	tests.CheckScanWithoutMutation(t, "s3", New, "s3://repeatr-test/test-"+testRunGuid+"/obj")
+	tests.CheckScanProducesConsistentHash(t, "s3", New, "s3://repeatr-test/test-"+testRunGuid+"/obj")
+	tests.CheckScanProducesDistinctHashes(t, "s3", New, "s3://repeatr-test/test-"+testRunGuid+"/obj")
 }

--- a/output/s3/s3_output_test.go
+++ b/output/s3/s3_output_test.go
@@ -1,1 +1,27 @@
 package s3
+
+import (
+	"testing"
+
+	"github.com/rlmcpherson/s3gof3r"
+	"polydawn.net/repeatr/output/tests"
+)
+
+// Note: most of the interesting tests are over in the paired inputs package;
+//  those demonstrate that we any of our interactions with S3 actually worked
+//   (beyond the level of "it didn't tell us it blew up" covered here).
+
+func TestCoreCompliance(t *testing.T) {
+	// FIXME: do a cleanup pass on these shared test things...
+	//   - they shouldn't be doing requirements (like ifHaveRoot) internally; that's caller's choice.
+	//   - they shouldn't be taking `t`, because that limits composability.
+	//   - looks like we're gonna need to be able to supply the URI to bounce to, as well.
+
+	if _, err := s3gof3r.EnvKeys(); err != nil {
+		t.Skipf("skipping s3 output tests; no s3 credentials loaded (err: %s)", err)
+	}
+
+	tests.CheckScanWithoutMutation(t, "s3", New)
+	tests.CheckScanProducesConsistentHash(t, "s3", New)
+	tests.CheckScanProducesDistinctHashes(t, "s3", New)
+}

--- a/output/tar2/tar_output_test.go
+++ b/output/tar2/tar_output_test.go
@@ -14,9 +14,9 @@ import (
 )
 
 func TestCoreCompliance(t *testing.T) {
-	tests.CheckScanWithoutMutation(t, "tar", New)
-	tests.CheckScanProducesConsistentHash(t, "tar", New)
-	tests.CheckScanProducesDistinctHashes(t, "tar", New)
+	tests.CheckScanWithoutMutation(t, "tar", New, "./output.dump.tar")
+	tests.CheckScanProducesConsistentHash(t, "tar", New, "./output.dump.tar")
+	tests.CheckScanProducesDistinctHashes(t, "tar", New, "./output.dump.tar")
 }
 
 func TestTarCompat(t *testing.T) {


### PR DESCRIPTION
MVP on using s3 as a data silo.

S3 is a k/v store and not an immediate mapping to a filesystem (despite what the UI may seem to suggest) -- to map to a full filesystem we need more bits for file attributes, etc.  This implementation uses tars as the metaphor for mapping filesystems onto s3.  (Another option would be using something like https://github.com/s3fs-fuse/s3fs-fuse -- this project has its own metaphor for mapping filesystems onto s3.  We decided not to use that for MVP because it's a much more complicated system; with this tarball approach, we know we can localize all network work before and after the job, rather than have interesting issues with random latency on disk mid-job.  http://dsl-wiki.cs.uchicago.edu/index.php/Performance_Comparison:Remote_Usage%2C_NFS%2C_S3-fuse%2C_EBS has some other interesting performance notes; there's no short answers to what's "fastest", apparently.  We can make more/different implementations in the future.)

https://github.com/rlmcpherson/s3gof3r was used to do the data shoveling and aws attribute auth signing stuff; appears to work really well.

Configuration of AWS secret tokens and keys is handled through environment variables for the time being.  We will probably want to expand on this later, building a general secrets management system, for at least two reasons: env vars placed before the entire repeatr system do not have the greatest scope limitations, and also they're effectively a global (what if someone wants to use two different s3 accounts?).  Works for now.

Includes a bunch of enhancements to the flexibility of the IO system shared test specs.  Tests now accept parameters for URIs.

This also demos the use of different URI schemes to switch storage behavior.  The "s3://" scheme will cause the rest of the URI location to be taken literally; the "s3+splay://" scheme will instead enable content-addressable naming of uploads, which means the same location string can be used for as a prefix for as much data as you want, and it will DTRT.  (Presuming this goes well, we should consider using URI schemes in the other transports too; this would also let us drop the current "type" field assertions and have transports check they recognize URI schemes, which makes a lot more sense when we get to configurable/pluginable dispatches for the IO transport systems.)  We've also talked about upgrading data location URIs to more complex structural data than strings can handle, but without any use cases or specific demos on the table yet, well... URIs still work well enough for jdbc after a decade or so, and we're not so different.

Setting up S3/AWS permissions models are *not* handled in this.  Those are arcana that should be managed by your organization, not repeatr.