### PR TITLE
Cli fix

### DIFF
--- a/executor/util/provision.go
+++ b/executor/util/provision.go
@@ -50,9 +50,9 @@ func ProvisionOutputs(outputs []def.Output, rootfs string, journal io.Writer) {
 func PreserveOutputs(outputs []def.Output, rootfs string, journal io.Writer) []def.Output {
 	for x, output := range outputs {
 		fmt.Fprintln(journal, "Persisting output", x+1, output.Type, "from", output.Location)
-		// path := filepath.Join(rootfs, output.Location)
+		path := filepath.Join(rootfs, output.Location)
 
-		report := <-outputdispatch.Get(output).Apply(rootfs)
+		report := <-outputdispatch.Get(output).Apply(path)
 		if report.Err != nil {
 			panic(report.Err)
 		}

--- a/output/dispatch/dispatch.go
+++ b/output/dispatch/dispatch.go
@@ -4,6 +4,7 @@ import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/output"
 	"polydawn.net/repeatr/output/tar"
+	"polydawn.net/repeatr/output/tar2"
 )
 
 func Get(desire def.Output) output.Output {
@@ -11,6 +12,8 @@ func Get(desire def.Output) output.Output {
 
 	switch desire.Type {
 	case "tar":
+		output = tar2.New(desire)
+	case "exec-tar":
 		output = tar.New(desire)
 	default:
 		panic(def.ValidationError.New("No such output %s", desire))

--- a/output/tar/tar_output.go
+++ b/output/tar/tar_output.go
@@ -35,7 +35,7 @@ func (o Output) Apply(rootPath string) <-chan output.Report {
 	go func() {
 		defer close(done)
 		try.Do(func() {
-			err := os.MkdirAll(rootPath, 0777)
+			err := os.MkdirAll(rootPath, 0755)
 			if err != nil {
 				panic(output.TargetFilesystemUnavailableIOError(err))
 			}

--- a/output/tar/tar_output.go
+++ b/output/tar/tar_output.go
@@ -30,7 +30,7 @@ func New(spec def.Output) *Output {
 	}
 }
 
-func (o Output) Apply(rootPath string) <-chan output.Report {
+func (o Output) Apply(basePath string) <-chan output.Report {
 	done := make(chan output.Report)
 	go func() {
 		defer close(done)
@@ -40,17 +40,14 @@ func (o Output) Apply(rootPath string) <-chan output.Report {
 				panic(output.TargetFilesystemUnavailableIOError(err))
 			}
 
-			// Assumes output URI is a folder. Output transport impls should obviously be more robust
-			path := filepath.Join(rootPath, o.spec.Location)
-
 			// exec tar.
 			// in case of a zero (a.k.a. success) exit, this returns silently.
 			// in case of a non-zero exit, this panics; the panic will include the output.
 			gosh.Gosh(
 				"tar",
 				"-cf", o.spec.URI,
-				"--xform", "s,"+strings.TrimLeft(rootPath, "/")+",,",
-				path,
+				"--xform", "s,"+strings.TrimLeft(basePath, "/")+",.,",
+				basePath,
 				gosh.NullIO,
 			).RunAndReport()
 

--- a/output/tar/tar_output.go
+++ b/output/tar/tar_output.go
@@ -35,7 +35,7 @@ func (o Output) Apply(rootPath string) <-chan output.Report {
 	go func() {
 		defer close(done)
 		try.Do(func() {
-			err := os.MkdirAll(rootPath, 0755)
+			err := os.MkdirAll(filepath.Dir(o.spec.URI), 0755)
 			if err != nil {
 				panic(output.TargetFilesystemUnavailableIOError(err))
 			}

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -43,7 +43,7 @@ func (o Output) Apply(basePath string) <-chan output.Report {
 		try.Do(func() {
 			// open output location for writing
 			// currently this impl assumes a local file uri
-			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
+			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY, 0644)
 			if err != nil {
 				panic(output.TargetFilesystemUnavailableIOError(err))
 			}

--- a/output/tar2/tar_output.go
+++ b/output/tar2/tar_output.go
@@ -43,7 +43,7 @@ func (o Output) Apply(basePath string) <-chan output.Report {
 		try.Do(func() {
 			// open output location for writing
 			// currently this impl assumes a local file uri
-			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0755)
+			file, err := os.OpenFile(o.spec.URI, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
 			if err != nil {
 				panic(output.TargetFilesystemUnavailableIOError(err))
 			}


### PR DESCRIPTION
Fix some random issues with the exec-tar output system discovered by running the cli -- the exec tar and the repeatr tar now behave identically.  Switch the default tar implementation to the hashing one (not sure why we didn't do so already; this now matches the pattern already in the inputs dispatch).