### PR TITLE
Export HashingReader.  Fix dir input to use.

### DIFF
--- a/lib/flak/hash.go
+++ b/lib/flak/hash.go
@@ -1,0 +1,23 @@
+package flak
+
+import (
+	"hash"
+	"io"
+)
+
+/*
+	Proxies a reader, hashing the stream as it's read.
+	(This is useful if using `io.Copy` to move bytes from a reader to
+	a writer, and you want to use that goroutine to power the hashing as
+	well but replacing the writer with a multiwriter is out of bounds.)
+*/
+type HashingReader struct {
+	R      io.Reader
+	Hasher hash.Hash
+}
+
+func (r *HashingReader) Read(b []byte) (int, error) {
+	n, err := r.R.Read(b)
+	r.Hasher.Write(b[:n])
+	return n, err
+}


### PR DESCRIPTION
Export HashingReader.  It lets us use e.g. `PlaceFile()` without extra copy workers.

Quietly fixes a bug in dir inputs: permissions bits on files were not being correctly set, and now are by virtue of reusing the already-tested paths in fs.PlaceFile.  (Tests coming as part of the io-reboot refactor will cover this.)

Yayy for diffs that are net removals of code!