### PR TITLE
Attach hashes structurally to HashMismatchErrors.

### DIFF
--- a/input/dir/dir_input.go
+++ b/input/dir/dir_input.go
@@ -58,7 +58,7 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 			// verify total integrity
 			expectedTreeHash, err := base64.URLEncoding.DecodeString(i.spec.Hash)
 			if !bytes.Equal(actualTreeHash, expectedTreeHash) {
-				done <- input.InputHashMismatchError.New("expected hash %q, got %q", i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
+				done <- input.NewHashMismatchError(i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
 			}
 		}).CatchAll(func(e error) {
 			// any errors should be caught and forwarded through a channel for management rather than killing the whole sytem unexpectedly.

--- a/input/errors.go
+++ b/input/errors.go
@@ -1,6 +1,7 @@
 package input
 
 import (
+	"fmt"
 	"github.com/spacemonkeygo/errors"
 )
 
@@ -36,6 +37,20 @@ func DataSourceUnavailableIOError(err error) *errors.Error {
 	active attack (i.e. MITM).
 */
 var InputHashMismatchError *errors.ErrorClass = DataSourceUnavailableError.NewClass("InputHashMismatchError")
+
+func NewHashMismatchError(expectedHash, actualHash string) *errors.Error {
+	return InputHashMismatchError.NewWith(
+		fmt.Sprintf("expected hash %q, got %q", expectedHash, actualHash),
+		errors.SetData(HashExpectedKey, expectedHash),
+		errors.SetData(HashActualKey, actualHash),
+	).(*errors.Error)
+}
+
+// Found on `InputHashMismatchError`
+var HashExpectedKey errors.DataKey = errors.GenSym()
+
+// Found on `InputHashMismatchError`
+var HashActualKey errors.DataKey = errors.GenSym()
 
 /*
 	Indicates that the target filesystem (the one given to `Apply`) had some error.

--- a/input/s3/s3_input.go
+++ b/input/s3/s3_input.go
@@ -101,7 +101,7 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 			// verify total integrity
 			expectedTreeHash, err := base64.URLEncoding.DecodeString(i.spec.Hash)
 			if !bytes.Equal(actualTreeHash, expectedTreeHash) {
-				done <- input.InputHashMismatchError.New("expected hash %q, got %q", i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
+				done <- input.NewHashMismatchError(i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
 			}
 		}).Catch(input.Error, func(err *errors.Error) {
 			done <- err

--- a/input/tar2/tar_input.go
+++ b/input/tar2/tar_input.go
@@ -80,7 +80,7 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 			// verify total integrity
 			expectedTreeHash, err := base64.URLEncoding.DecodeString(i.spec.Hash)
 			if !bytes.Equal(actualTreeHash, expectedTreeHash) {
-				done <- input.InputHashMismatchError.New("expected hash %q, got %q", i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
+				done <- input.NewHashMismatchError(i.spec.Hash, base64.URLEncoding.EncodeToString(actualTreeHash))
 			}
 		}).Catch(input.Error, func(err *errors.Error) {
 			done <- err


### PR DESCRIPTION
Sticking values irretreivably in fmt strings is a poor idea.  Put them into data keys instead, so they can be re-examined later.

Also, standardize the way HashMismatchError are created, so their fmt strings aren't copypasta'd around.