### PR TITLE
Scan command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -4,10 +4,6 @@ import (
 	"io"
 
 	"github.com/codegangsta/cli"
-
-	"polydawn.net/repeatr/def"
-	"polydawn.net/repeatr/executor/dispatch"
-	"polydawn.net/repeatr/scheduler/dispatch"
 )
 
 func Main(args []string, journal, output io.Writer) {
@@ -19,46 +15,10 @@ func Main(args []string, journal, output io.Writer) {
 
 	App.Writer = journal
 
-	bat := cli.StringSlice([]string{})
-
 	App.Commands = []cli.Command{
-		{
-			Name:   "run",
-			Usage:  "Run a formula",
-			Action: func(c *cli.Context) { Run(c, journal) },
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "executor, e",
-					Value: "chroot",
-					Usage: "Which executor to use",
-				},
-				cli.StringFlag{
-					Name:  "scheduler, s",
-					Value: "linear",
-					Usage: "Location of input formula (json format)",
-				},
-				cli.StringSliceFlag{
-					Name:  "input, i",
-					Value: &bat,
-					Usage: "Location of input formulae (json format)",
-				},
-			},
-		},
+		RunCommandPattern(journal),
 		ScanCommandPattern(journal, output),
 	}
 
 	App.Run(args)
-}
-
-func Run(c *cli.Context, journal io.Writer) {
-	executor := executordispatch.Get(c.String("executor"))
-	scheduler := schedulerdispatch.Get(c.String("scheduler"))
-	paths := c.StringSlice("input")
-
-	var formulae []def.Formula
-	for _, path := range paths {
-		formulae = append(formulae, LoadFormulaFromFile(path))
-	}
-
-	RunFormulae(scheduler, executor, journal, formulae...)
 }

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,15 +1,16 @@
 package cli
 
 import (
-	"github.com/codegangsta/cli"
 	"io"
+
+	"github.com/codegangsta/cli"
 
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor/dispatch"
 	"polydawn.net/repeatr/scheduler/dispatch"
 )
 
-func Main(args []string, journal io.Writer) {
+func Main(args []string, journal, output io.Writer) {
 	App := cli.NewApp()
 
 	App.Name = "repeatr"
@@ -43,7 +44,7 @@ func Main(args []string, journal io.Writer) {
 				},
 			},
 		},
-		ScanCommand,
+		ScanCommandPattern(journal, output),
 	}
 
 	App.Run(args)

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -43,6 +43,7 @@ func Main(args []string, journal io.Writer) {
 				},
 			},
 		},
+		ScanCommand,
 	}
 
 	App.Run(args)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -26,7 +26,7 @@ func Test(t *testing.T) {
 	}
 
 	Convey("It should not crash without args", t, func() {
-		Main(baseArgs, ioutil.Discard)
+		Main(baseArgs, ioutil.Discard, ioutil.Discard)
 	})
 
 	Convey("It should run a basic example", t,
@@ -34,7 +34,7 @@ func Test(t *testing.T) {
 			testutil.RequiresRoot,
 			testutil.RequiresNamespaces,
 			func() {
-				Main(append(baseArgs, "run", "-i", "lib/integration/basic.json"), ioutil.Discard)
+				Main(append(baseArgs, "run", "-i", "lib/integration/basic.json"), ioutil.Discard, ioutil.Discard)
 			},
 		),
 	)

--- a/cli/run.go
+++ b/cli/run.go
@@ -56,6 +56,7 @@ func RunFormulae(s scheduler.Scheduler, e executor.Executor, journal io.Writer, 
 
 			fmt.Fprintln(journal, "Job", n, id, "queued")
 			job := <-jobChan
+			// TODO need better lifecycle events here.  "starting" here means we might still be in provisioning stage.
 			fmt.Fprintln(journal, "Job", n, id, "starting")
 
 			// Stream job output to terminal in real time

--- a/cli/run.go
+++ b/cli/run.go
@@ -31,7 +31,14 @@ func LoadFormulaFromFile(path string) def.Formula {
 }
 
 func RunFormulae(s scheduler.Scheduler, e executor.Executor, journal io.Writer, f ...def.Formula) {
-	s.Configure(e, len(f)) // we know exactly how many forumlae will be enqueued
+	jobLoggerFactory := func(_ def.JobID) io.Writer {
+		// All job progress reporting actually still copy to our shared journal stream.
+		// This should be replaced with a real logging framework,
+		//  at which point we can add tags for jobID before handing out specialized loggers.
+		return journal
+	}
+
+	s.Configure(e, len(f), jobLoggerFactory) // we know exactly how many forumlae will be enqueued
 	s.Start()
 
 	var wg sync.WaitGroup

--- a/cli/run_command.go
+++ b/cli/run_command.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/codegangsta/cli"
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/executor/dispatch"
+	"polydawn.net/repeatr/scheduler"
+	"polydawn.net/repeatr/scheduler/dispatch"
+)
+
+func RunCommandPattern(journal io.Writer) cli.Command {
+	bat := cli.StringSlice([]string{})
+	return cli.Command{
+		Name:  "run",
+		Usage: "Run a formula",
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "executor, e",
+				Value: "chroot",
+				Usage: "Which executor to use",
+			},
+			cli.StringFlag{
+				Name:  "scheduler, s",
+				Value: "linear",
+				Usage: "Location of input formula (json format)",
+			},
+			cli.StringSliceFlag{
+				Name:  "input, i",
+				Value: &bat,
+				Usage: "Location of input formulae (json format)",
+			},
+		},
+		Action: func(c *cli.Context) {
+			executor := executordispatch.Get(c.String("executor"))
+			scheduler := schedulerdispatch.Get(c.String("scheduler"))
+			formulaPaths := c.StringSlice("input")
+			Run(executor, scheduler, formulaPaths, journal)
+		},
+	}
+}
+
+func Run(executor executor.Executor, scheduler scheduler.Scheduler, formulaPaths []string, journal io.Writer) {
+	var formulae []def.Formula
+	for _, path := range formulaPaths {
+		formulae = append(formulae, LoadFormulaFromFile(path))
+	}
+
+	RunFormulae(scheduler, executor, journal, formulae...)
+}

--- a/cli/run_command.go
+++ b/cli/run_command.go
@@ -48,5 +48,8 @@ func Run(executor executor.Executor, scheduler scheduler.Scheduler, formulaPaths
 		formulae = append(formulae, LoadFormulaFromFile(path))
 	}
 
+	// TODO Don't reeeeally want the 'run once' command going through the schedulers.
+	//  Having a path that doesn't invoke that complexity unnecessarily, and also is more clearly allowed to use the current terminal, is want.
+
 	RunFormulae(scheduler, executor, journal, formulae...)
 }

--- a/cli/scan_command.go
+++ b/cli/scan_command.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/codegangsta/cli"
-
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor/util"
 	"polydawn.net/repeatr/io"

--- a/cli/scan_command.go
+++ b/cli/scan_command.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor/util"
+	"polydawn.net/repeatr/io"
+)
+
+var ScanCommand = cli.Command{
+	Name:  "scan",
+	Usage: "Scan a local filesystem, optionally storing the data into a silo",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "kind",
+			Usage: "What kind of data storage format to work with.",
+		},
+		cli.StringFlag{
+			Name:  "path",
+			Value: ".",
+			Usage: "Optional.  The local filesystem path to scan.  Defaults to your current directory.",
+		},
+		cli.StringFlag{
+			Name:  "uri",
+			Usage: "Optional.  A Silo URI to upload data to.",
+		},
+	},
+	Action: func(ctx *cli.Context) {
+		// args parse
+		outputSpec := def.Output{
+			Type: ctx.String("kind"),
+			URI:  ctx.String("uri"),
+			// Filters: might want
+			Location: ctx.String("path"),
+		}
+		if outputSpec.Type == "" {
+			panic(Error.NewWith("Missing argument: \"kind\" is a required parameter for scan", SetExitCode(EXIT_BADARGS)))
+		}
+		if outputSpec.Location == "" {
+			outputSpec.Location = "."
+		}
+		// invoke
+		outputResult := Scan(outputSpec)
+		// output
+		// FIXME serialization format.
+		//  also golang is shuffling values and That Is So Annoying to read as a human.
+		//   give up and write a custom marshal method.
+		//    really, you want that anyway for things like hassle-free syntax in practice for single URIs without an array, etc.
+		msg, err := json.Marshal(outputResult)
+		if err != nil {
+			panic(err)
+		}
+		// FIXME turn this back into a function so we can pass down chosen output streams
+		fmt.Fprintf(os.Stdout, "%s\n", string(msg))
+	},
+}
+
+/*
+	Spits out a chunk of json on stdout that can be used as
+	a `Input` specification in a `Formula`.
+*/
+func Scan(outputSpec def.Output) def.Output {
+	// TODO validate Location exists, give nice errors
+
+	siloURIs := []integrity.SiloURI{
+		integrity.SiloURI(outputSpec.URI),
+	}
+	if outputSpec.URI == "" {
+		// ugly.  figure out how we want the user-facing API to see multiple silo URIs.
+		siloURIs = nil
+	}
+
+	// So, this CLI command is *not* in its rights to change the subject area,
+	//  so take that as a pretty strong hint that filters are going to have to pass down *into* transmats.
+	commitID := util.DefaultTransmat().Scan(
+		// All of this stuff that's type-coercing?
+		//  Yeah these are hints that this stuff should be facing data validation.
+		integrity.TransmatKind(outputSpec.Type),
+		outputSpec.Location,
+		siloURIs,
+	)
+
+	return def.Output{
+		Type: outputSpec.Type,
+		URI:  outputSpec.URI,
+		Hash: string(commitID),
+	}
+}

--- a/demo.sh
+++ b/demo.sh
@@ -67,7 +67,7 @@ echo -e "${clblue}#  This first run might take a while -- it's downloading an op
 			{
 				"Type": "s3",
 				"Location": "/",
-				"Hash": "l-I1HXpvEDIOCcd1leNW7vdxh7UrUbCdjZaWiflvB8kp4DM91STRXm1gYG4K8Cm2",
+				"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
 				"URI": "s3+splay://repeatr/assets/"
 			}
 		],
@@ -101,7 +101,7 @@ echo -e "${clblue}#  Here we use the same rootfs image of ubuntu, so it starts i
 			{
 				"Type": "s3",
 				"Location": "/",
-				"Hash": "l-I1HXpvEDIOCcd1leNW7vdxh7UrUbCdjZaWiflvB8kp4DM91STRXm1gYG4K8Cm2",
+				"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
 				"URI": "s3+splay://repeatr/assets/"
 			}
 		],

--- a/demo.sh
+++ b/demo.sh
@@ -2,7 +2,17 @@
 set -eo pipefail
 
 if [ -f .gopath/bin/repeatr ]; then PATH=$PWD/.gopath/bin/:$PATH; fi
+if [ "$1" != "-t" ]; then straight=true; fi; export straight;
 demodir="demo";
+
+cnbrown="$(echo -ne "\E[0;33m")" # prompt
+clblue="$(echo -ne "\E[1;34m")"  # section docs
+cnone="$(echo -ne "\E[0m")"
+awaitack() {
+	[ "$straight" != true ] && return;
+	echo -ne "${cnbrown}waiting for ye to hit enter, afore the voyage heave up anchor and make headway${cnone}"
+	read -es && echo -ne "\E[F\E[2K\r"
+}
 
 rm -rf "$demodir"
 mkdir -p "$demodir" && cd "$demodir" && demodir="$(pwd)"
@@ -10,36 +20,57 @@ echo "$demodir"
 
 
 
-set -x
 
-
-
-repeatr scan --kind=tar
-
-
-
-repeatr run -i <(cat <<EOF
-{
-	"Inputs": [
-		{
-			"Type": "tar",
-			"Location": "/",
-			"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
-			"URI": "assets/ubuntu.tar.gz"
-		}
-	],
-	"Accents": {
-		"Entrypoint": [ "echo", "Hello from repeatr!" ]
-	},
-	"Outputs": [
-		{
-			"Type": "tar",
-			"Location": "/var/log",
-			"URI": "basic.tar"
-		}
-	]
-}
-EOF
+echo -e "${clblue}# Repeatr says hello!${cnone}"
+echo -e "${clblue}#  Without a command, it provides help.${cnone}"
+(
+	repeatr
 )
+echo -e "${clblue} ----------------------------${cnone}\n\n"
+awaitack
 
+
+echo -e "${clblue}# To suck in data, use the scan command:${cnone}"
+echo
+(
+	repeatr scan --kind=tar
+)
+echo
+echo -e "${clblue}#  This determines the data identity,${cnone}"
+echo -e "${clblue}#   Uploads it to a warehouse,${cnone}"
+echo -e "${clblue}#    And outputs the config to request it again later.${cnone}"
+echo -e "${clblue} ----------------------------${cnone}\n\n"
+awaitack
+
+
+
+
+echo -e "${clblue}# \`repeatr run\` takes a job description and executes it.${cnone}"
+echo -e "${clblue}#  Stdout goes to your terminal;${cnone}"
+echo -e "${clblue}#   Any 'output' specifications are saved/uploaded.${cnone}"
+(
+	repeatr run -i <(cat <<-EOF
+	{
+		"Inputs": [
+			{
+				"Type": "tar",
+				"Location": "/",
+				"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
+				"URI": "assets/ubuntu.tar.gz"
+			}
+		],
+		"Accents": {
+			"Entrypoint": [ "echo", "Hello from repeatr!" ]
+		},
+		"Outputs": [
+			{
+				"Type": "tar",
+				"Location": "/var/log",
+				"URI": "basic.tar"
+			}
+		]
+	}
+EOF
+	)
+)
 

--- a/demo.sh
+++ b/demo.sh
@@ -22,6 +22,7 @@ tellRunning() {
 rm -rf "$demodir"
 mkdir -p "$demodir" && cd "$demodir" && demodir="$(pwd)"
 echo "$demodir"
+echo "$(which repeatr)"
 
 export REPEATR_BASE="$demodir/repeatr_base"
 

--- a/demo.sh
+++ b/demo.sh
@@ -57,6 +57,7 @@ awaitack
 
 echo -e "${clblue}# The \`repeatr run\` command takes a job description and executes it.${cnone}"
 echo -e "${clblue}#  Stdout goes to your terminal; any 'output' specifications are saved/uploaded.${cnone}"
+echo -e "${clblue}#  This first run might take a while -- it's downloading an operating system image first!${cnone}"
 (
 	tellRunning "repeatr run -i some-json-config-files.conf"
 	repeatr run -i <(cat <<-EOF
@@ -83,6 +84,42 @@ echo -e "${clblue}#  Stdout goes to your terminal; any 'output' specifications a
 EOF
 	)
 )
+echo -e "${clblue} ----------------------------${cnone}\n\n"
+awaitack
+
+
+
+
+echo -e "${clblue}# The \`repeatr run\` command can used cached assets to start jobs faster.${cnone}"
+echo -e "${clblue}#  Here we use the same rootfs image of ubuntu, so it starts instantly.${cnone}"
+(
+	tellRunning "time repeatr run -i some-json-config-files.conf"
+	time repeatr run -i <(cat <<-EOF
+	{
+		"Inputs": [
+			{
+				"Type": "s3",
+				"Location": "/",
+				"Hash": "l-I1HXpvEDIOCcd1leNW7vdxh7UrUbCdjZaWiflvB8kp4DM91STRXm1gYG4K8Cm2",
+				"URI": "s3+splay://repeatr/assets/"
+			}
+		],
+		"Accents": {
+			"Entrypoint": [ "echo", "Hello from repeatr!" ]
+		},
+		"Outputs": [
+			{
+				"Type": "tar",
+				"Location": "/var/log",
+				"URI": "basic.tar"
+			}
+		]
+	}
+EOF
+	)
+)
+echo -e "${clblue}# Also, note that the output is the same hash?${cnone}"
+echo -e "${clblue}#  Given the same inputs, this command produces the same outputs, every time. ;)${cnone}"
 echo -e "${clblue} ----------------------------${cnone}\n\n"
 awaitack
 

--- a/demo.sh
+++ b/demo.sh
@@ -23,6 +23,7 @@ rm -rf "$demodir"
 mkdir -p "$demodir" && cd "$demodir" && demodir="$(pwd)"
 echo "$demodir"
 
+export REPEATR_BASE="$demodir/repeatr_base"
 
 
 
@@ -62,10 +63,10 @@ echo -e "${clblue}#  Stdout goes to your terminal; any 'output' specifications a
 	{
 		"Inputs": [
 			{
-				"Type": "tar",
+				"Type": "s3",
 				"Location": "/",
-				"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
-				"URI": "assets/ubuntu.tar.gz"
+				"Hash": "l-I1HXpvEDIOCcd1leNW7vdxh7UrUbCdjZaWiflvB8kp4DM91STRXm1gYG4K8Cm2",
+				"URI": "s3+splay://repeatr/assets/"
 			}
 		],
 		"Accents": {

--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eo pipefail
+
+if [ -f .gopath/bin/repeatr ]; then PATH=$PWD/.gopath/bin/:$PATH; fi
+demodir="demo";
+
+rm -rf "$demodir"
+mkdir -p "$demodir" && cd "$demodir" && demodir="$(pwd)"
+echo "$demodir"
+
+
+
+set -x
+
+
+
+repeatr scan --kind=tar
+
+
+
+repeatr run -i <(cat <<EOF
+{
+	"Inputs": [
+		{
+			"Type": "tar",
+			"Location": "/",
+			"Hash": "b6nXWuXamKB3TfjdzUSL82Gg1avuvTk0mWQP4wgegscZ_ZzG9GfHDwKXQ9BfCx6v",
+			"URI": "assets/ubuntu.tar.gz"
+		}
+	],
+	"Accents": {
+		"Entrypoint": [ "echo", "Hello from repeatr!" ]
+	},
+	"Outputs": [
+		{
+			"Type": "tar",
+			"Location": "/var/log",
+			"URI": "basic.tar"
+		}
+	]
+}
+EOF
+)
+
+

--- a/demo.sh
+++ b/demo.sh
@@ -6,12 +6,17 @@ if [ "$1" != "-t" ]; then straight=true; fi; export straight;
 demodir="demo";
 
 cnbrown="$(echo -ne "\E[0;33m")" # prompt
+clblack="$(echo -ne "\E[1;30m")" # aside
+clbrown="$(echo -ne "\E[1;33m")" # command
 clblue="$(echo -ne "\E[1;34m")"  # section docs
 cnone="$(echo -ne "\E[0m")"
 awaitack() {
 	[ "$straight" != true ] && return;
 	echo -ne "${cnbrown}waiting for ye to hit enter, afore the voyage heave up anchor and make headway${cnone}"
 	read -es && echo -ne "\E[F\E[2K\r"
+}
+tellRunning() {
+	echo -e "${clblack}# running \`${clbrown}$@${clblack}\` >>>${cnone}"
 }
 
 rm -rf "$demodir"
@@ -24,6 +29,7 @@ echo "$demodir"
 echo -e "${clblue}# Repeatr says hello!${cnone}"
 echo -e "${clblue}#  Without a command, it provides help.${cnone}"
 (
+	tellRunning "repeatr"
 	repeatr
 )
 echo -e "${clblue} ----------------------------${cnone}\n\n"
@@ -33,6 +39,9 @@ awaitack
 echo -e "${clblue}# To suck in data, use the scan command:${cnone}"
 echo
 (
+	tellRunning "repeatr scan --help"
+	repeatr scan --help
+	tellRunning "repeatr scan --kind=tar"
 	repeatr scan --kind=tar
 )
 echo
@@ -45,10 +54,10 @@ awaitack
 
 
 
-echo -e "${clblue}# \`repeatr run\` takes a job description and executes it.${cnone}"
-echo -e "${clblue}#  Stdout goes to your terminal;${cnone}"
-echo -e "${clblue}#   Any 'output' specifications are saved/uploaded.${cnone}"
+echo -e "${clblue}# The \`repeatr run\` command takes a job description and executes it.${cnone}"
+echo -e "${clblue}#  Stdout goes to your terminal; any 'output' specifications are saved/uploaded.${cnone}"
 (
+	tellRunning "repeatr run -i some-json-config-files.conf"
 	repeatr run -i <(cat <<-EOF
 	{
 		"Inputs": [
@@ -73,4 +82,10 @@ echo -e "${clblue}#   Any 'output' specifications are saved/uploaded.${cnone}"
 EOF
 	)
 )
+echo -e "${clblue} ----------------------------${cnone}\n\n"
+awaitack
+
+
+echo "${clblue}#  That's all!  Neat, eh?${cnone}"
+
 

--- a/executor/util/provision.go
+++ b/executor/util/provision.go
@@ -52,6 +52,7 @@ func ProvisionInputs(transmat integrity.Transmat, assemblerFn integrity.Assemble
 			filesystems[in] = report.Arena
 		}
 	}
+	fmt.Fprintf(journal, "All inputs acquired... starting assembly\n")
 
 	// assemble them into the final tree
 	assemblyParts := make([]integrity.AssemblyPart, 0, len(filesystems))
@@ -63,6 +64,7 @@ func ProvisionInputs(transmat integrity.Transmat, assemblerFn integrity.Assemble
 		})
 	}
 	assembly := assemblerFn(rootfs, assemblyParts)
+	fmt.Fprintf(journal, "Assembly complete!\n")
 	return assembly
 }
 

--- a/input/s3/s3_input.go
+++ b/input/s3/s3_input.go
@@ -71,6 +71,8 @@ func (i Input) Apply(destinationRoot string) <-chan error {
 
 			// load keys from env
 			// TODO someday URIs should grow smart enough to control this in a more general fashion -- but for now, host ENV is actually pretty feasible and plays easily with others.
+			// TODO should not require keys!  we're just reading, after all; anon access is 100% valid.
+			//   Buuuuut s3gof3r doesn't seem to understand empty keys; it still sends them as if to login, and AWS says 403.  So, foo.
 			keys, err := s3gof3r.EnvKeys()
 			if err != nil {
 				panic(S3CredentialsMissingError.Wrap(err))

--- a/repeatr.go
+++ b/repeatr.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	try.Do(func() {
-		cli.Main(os.Args, os.Stderr)
+		cli.Main(os.Args, os.Stderr, os.Stdout)
 	}).Catch(cli.Error, func(err *errors.Error) {
 		// Errors marked as valid user-facing issues get a nice
 		// pretty-printed route out, and may include specified exit codes.

--- a/repeatr.go
+++ b/repeatr.go
@@ -25,7 +25,7 @@ func main() {
 			fmt.Fprintf(os.Stderr,
 				"Repeatr was unable to complete your request!\n"+
 					"%s\n",
-				err)
+				err.Message())
 			// exit, taking the specified code if any.
 			code := errors.GetData(err, cli.ExitCodeKey)
 			if code == nil {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -1,6 +1,8 @@
 package scheduler
 
 import (
+	"io"
+
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 )
@@ -25,7 +27,7 @@ type Scheduler interface {
 		It is guaranteed that calling Use() before scheduling work will behave as expected.
 		Calling Use() after scheduling work is left for the Scheduler to decide - it might change, panic, ignore, etc.
 	*/
-	Configure(e executor.Executor, queueSize int)
+	Configure(e executor.Executor, queueSize int, jobLoggerFactory func(def.JobID) io.Writer)
 
 	/*
 		Start consuming Formulas.


### PR DESCRIPTION
CLI upgrades, and a new `repeatr scan` subcommand.

`repeatr scan` invokes the output scan & upload functionality on a local filesystem path.  It produces a json chunk on stdout that can be used directly as configuration for an input.

Some logging that was getting devnull'd has been reconnected (though shoddily -- we need a logging framework, stat).

Fix output of CLIErrors to be more friendly.

 A `demo.sh` script now exists.  This does a slow, semi-interactive showcase of a variety of repeatr features, invoked from bash exactly as a normal user would.

:warning: contains (lots of) commits from other PRs: rebasing will remove them after #52 lands.  EDIT: done.