### PR TITLE
Filters

### DIFF
--- a/io/filter/filter.go
+++ b/io/filter/filter.go
@@ -7,6 +7,13 @@
 	the "modified time" properties from files -- since executing most
 	applications results in a spray of unique and unrepeatable mtime properties,
 	it's usually best to discard them.
+
+	Typically, filters should be applied on output scans -- it makes sense
+	to do data normalization *before* warehousing, both on general principle,
+	and because it will make data deduplicate better.  However, filters
+	may also be used on input/materialization; this may be useful in
+	circumstances where the data committed to warehouse has various UIDs,
+	but the local environment wants to get them all as the current UID.
 */
 package filter
 

--- a/io/filter/filter.go
+++ b/io/filter/filter.go
@@ -1,0 +1,19 @@
+/*
+	Filters are used for normalizing/flattening attributes of filesystems,
+	so that we can discard uninteresting pieces of information, or flatten
+	them for the sake of consistency.
+
+	One example of a useful filter is the "mtime" filter, which strips all
+	the "modified time" properties from files -- since executing most
+	applications results in a spray of unique and unrepeatable mtime properties,
+	it's usually best to discard them.
+*/
+package filter
+
+import (
+	"polydawn.net/repeatr/lib/fs"
+)
+
+type Filter interface {
+	Filter(fs.Metadata) fs.Metadata
+}

--- a/io/filter/gid_filter.go
+++ b/io/filter/gid_filter.go
@@ -1,0 +1,16 @@
+package filter
+
+import (
+	"polydawn.net/repeatr/lib/fs"
+)
+
+var _ Filter = GidFilter{}
+
+type GidFilter struct {
+	Value int
+}
+
+func (f GidFilter) Filter(attribs fs.Metadata) fs.Metadata {
+	attribs.Gid = f.Value
+	return attribs
+}

--- a/io/filter/mtime_filter.go
+++ b/io/filter/mtime_filter.go
@@ -1,0 +1,18 @@
+package filter
+
+import (
+	"time"
+
+	"polydawn.net/repeatr/lib/fs"
+)
+
+var _ Filter = MtimeFilter{}
+
+type MtimeFilter struct {
+	Value time.Time
+}
+
+func (f MtimeFilter) Filter(attribs fs.Metadata) fs.Metadata {
+	attribs.ModTime = f.Value
+	return attribs
+}

--- a/io/filter/uid_filter.go
+++ b/io/filter/uid_filter.go
@@ -1,0 +1,16 @@
+package filter
+
+import (
+	"polydawn.net/repeatr/lib/fs"
+)
+
+var _ Filter = UidFilter{}
+
+type UidFilter struct {
+	Value int
+}
+
+func (f UidFilter) Filter(attribs fs.Metadata) fs.Metadata {
+	attribs.Uid = f.Value
+	return attribs
+}


### PR DESCRIPTION
First pass on adding "filters".

Filters are the feature for flattening filesystem attributes, long-alluded-to in the formula definitions.  This is useful for two major purposes:

- flattening uninteresting attributes on output (e.g. mtime, which is often (but not always!) meaningless), which can help make output hashes consistent
- flattening unhelpful attributes on input (e.g. skip uid, which though often critical (especially in the root of a container filesystem), requires root, which we may sometimes prefer to skip).

Filters will probably be few enough that we won't need a plugin system for them -- if you really need exotic stuff, there's no reason you can't put it in a script inside your job, after all -- and thus we're just going to have a very short list of things with basic string names.  These will be **well known** to transmats, as they may trigger conditional branches (and this is really the only reason we don't just provide them as a first-class feature rather than just helper scripts to use inside your job) -- for example the uid filter won't just flatten the uid; the transmat may recognize the filter's purpose, and simply *not make the chown call* to begin with.

This is a draft; this function signature should suffice, but this change set doesn't yet connect them.