### PR TITLE
Runc executor

### DIFF
--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -123,9 +123,9 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, result *def.JobRe
 	// see comments in gosh tests with chroot for information about the odd behavior we're hacking around here;
 	// we're comfortable making this special check here, but not upstreaming it to gosh, because in our context we "know" we're not racing anyone.
 	if externalCwdStat, err := os.Stat(filepath.Join(rootfs, f.Action.Cwd)); err != nil {
-		panic(executor.TaskExecError.New("cannot set cwd to %q: %s", f.Action.Cwd, err.(*os.PathError).Err))
+		panic(executor.NoSuchCwdError.New("cannot set cwd to %q: %s", f.Action.Cwd, err.(*os.PathError).Err))
 	} else if !externalCwdStat.IsDir() {
-		panic(executor.TaskExecError.New("cannot set cwd to %q: not a dir", f.Action.Cwd))
+		panic(executor.NoSuchCwdError.New("cannot set cwd to %q: not a dir", f.Action.Cwd))
 	}
 	cmd.Dir = f.Action.Cwd
 

--- a/executor/chroot/chroot_executor.go
+++ b/executor/chroot/chroot_executor.go
@@ -125,7 +125,7 @@ func (e *Executor) Execute(f def.Formula, j def.Job, d string, result *def.JobRe
 	if externalCwdStat, err := os.Stat(filepath.Join(rootfs, f.Action.Cwd)); err != nil {
 		panic(executor.NoSuchCwdError.New("cannot set cwd to %q: %s", f.Action.Cwd, err.(*os.PathError).Err))
 	} else if !externalCwdStat.IsDir() {
-		panic(executor.NoSuchCwdError.New("cannot set cwd to %q: not a dir", f.Action.Cwd))
+		panic(executor.NoSuchCwdError.New("cannot set cwd to %q: not a directory", f.Action.Cwd))
 	}
 	cmd.Dir = f.Action.Cwd
 

--- a/executor/chroot/chroot_executor_test.go
+++ b/executor/chroot/chroot_executor_test.go
@@ -22,6 +22,7 @@ func Test(t *testing.T) {
 				tests.CheckFilesystemContainment(execEng)
 				tests.CheckPwdBehavior(execEng)
 				tests.CheckEnvBehavior(execEng)
+				//tests.CheckHostnameBehavior(execEng) // not supportable with chroot
 			}),
 		),
 	)

--- a/executor/dispatch/dispatch.go
+++ b/executor/dispatch/dispatch.go
@@ -8,6 +8,7 @@ import (
 	"polydawn.net/repeatr/executor/chroot"
 	"polydawn.net/repeatr/executor/nsinit"
 	"polydawn.net/repeatr/executor/null"
+	"polydawn.net/repeatr/executor/runc"
 )
 
 // TODO: This should not require a global string -> class map :|
@@ -24,6 +25,8 @@ func Get(desire string) executor.Executor {
 		executor = &nsinit.Executor{}
 	case "chroot":
 		executor = &chroot.Executor{}
+	case "runc":
+		executor = &runc.Executor{}
 	default:
 		panic(def.ValidationError.New("No such executor %s", desire))
 	}

--- a/executor/errors.go
+++ b/executor/errors.go
@@ -22,12 +22,24 @@ var ConfigError *errors.ErrorClass = Error.NewClass("ExecutorConfigError")
 var TaskExecError *errors.ErrorClass = Error.NewClass("ExecutorTaskExecError")
 
 /*
-	Error raised when a command is not found inside the execution environment.
+	Error raised when job launched failed because the command is
+	not found inside the execution environment.
 
-	Often just indicative of user misconfiguration (and thus this is not a
-	child of TaskExecError, which expresses serious system failures).
+	This is considered a form of config error since the command and
+	the filesystem are both configured together, meaning a mismatch
+	between them is operator error.
 */
-var NoSuchCommandError *errors.ErrorClass = Error.NewClass("NoSuchCommandError")
+var NoSuchCommandError *errors.ErrorClass = ConfigError.NewClass("NoSuchCommandError")
+
+/*
+	Error raised when job launched failed because the requested "cwd"
+	is either not found or not a directory inside the execution environment.
+
+	This is considered a form of config error since the command and
+	the filesystem are both configured together, meaning a mismatch
+	between them is operator error.
+*/
+var NoSuchCwdError *errors.ErrorClass = ConfigError.NewClass("NoSuchCwdError")
 
 /*
 	Wraps any other unknown errors just to emphasize the system that raised them;

--- a/executor/nsinit/nsinit_executor_test.go
+++ b/executor/nsinit/nsinit_executor_test.go
@@ -23,6 +23,7 @@ func Test(t *testing.T) {
 				tests.CheckFilesystemContainment(execEng)
 				//tests.CheckPwdBehavior(execEng) // correct error reporting sections fail spec compliance
 				tests.CheckEnvBehavior(execEng)
+				//tests.CheckHostnameBehavior(execEng) // not yet implemented
 			}),
 		),
 	)

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -29,7 +29,7 @@ func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
 		},
 		"root": map[string]interface{}{
 			"path":     rootPath,
-			"readonly": true,
+			"readonly": false,
 		},
 		"hostname": "shell",
 		"mounts": []interface{}{

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -12,7 +12,7 @@ func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
 			"arch": "amd64",
 		},
 		"process": map[string]interface{}{
-			"terminal": true,
+			//"terminal": true,
 			"user": map[string]interface{}{
 				"uid":            0,
 				"gid":            0,

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -4,7 +4,7 @@ import (
 	"polydawn.net/repeatr/def"
 )
 
-func EmitRuncConfigStruct(frm def.Formula) interface{} {
+func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
 	return map[string]interface{}{
 		"version": "0.1.0",
 		"platform": map[string]interface{}{
@@ -28,7 +28,7 @@ func EmitRuncConfigStruct(frm def.Formula) interface{} {
 			"cwd": frm.Action.Cwd,
 		},
 		"root": map[string]interface{}{
-			"path":     "rootfs",
+			"path":     rootPath,
 			"readonly": true,
 		},
 		"hostname": "shell",

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -6,7 +6,7 @@ import (
 
 func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
 	return map[string]interface{}{
-		"version": "0.1.0",
+		"version": "0.2.0",
 		"platform": map[string]interface{}{
 			"os":   "linux",
 			"arch": "amd64",

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -1,283 +1,143 @@
 package runc
 
-var confConfigTmpl = `{
-	"version": "0.1.0",
-	"platform": {
-		"os": "linux",
-		"arch": "amd64"
-	},
-	"process": {
-		"terminal": true,
-		"user": {
-			"uid": 0,
-			"gid": 0,
-			"additionalGids": null
-		},
-		"args": [
-			"sh"
-		],
-		"env": [
-			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-			"TERM=xterm"
-		],
-		"cwd": ""
-	},
-	"root": {
-		"path": "rootfs",
-		"readonly": true
-	},
-	"hostname": "shell",
-	"mounts": [
-		{
-			"name": "proc",
-			"path": "/proc"
-		},
-		{
-			"name": "dev",
-			"path": "/dev"
-		},
-		{
-			"name": "devpts",
-			"path": "/dev/pts"
-		},
-		{
-			"name": "shm",
-			"path": "/dev/shm"
-		},
-		{
-			"name": "mqueue",
-			"path": "/dev/mqueue"
-		},
-		{
-			"name": "sysfs",
-			"path": "/sys"
-		},
-		{
-			"name": "cgroup",
-			"path": "/sys/fs/cgroup"
-		}
-	],
-	"linux": {
-		"capabilities": [
-			"CAP_AUDIT_WRITE",
-			"CAP_KILL",
-			"CAP_NET_BIND_SERVICE"
-		]
-	}
-}`
+import (
+	"polydawn.net/repeatr/def"
+)
 
-var confRuntimeTmpl = `{
-	"mounts": {
-		"cgroup": {
-			"type": "cgroup",
-			"source": "cgroup",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev",
-				"relatime",
-				"ro"
-			]
+func EmitRuncConfigStruct(frm def.Formula) interface{} {
+	return map[string]interface{}{
+		"version": "0.1.0",
+		"platform": map[string]interface{}{
+			"os":   "linux",
+			"arch": "amd64",
 		},
-		"dev": {
-			"type": "tmpfs",
-			"source": "tmpfs",
-			"options": [
-				"nosuid",
-				"strictatime",
-				"mode=755",
-				"size=65536k"
-			]
+		"process": map[string]interface{}{
+			"terminal": true,
+			"user": map[string]interface{}{
+				"uid":            0,
+				"gid":            0,
+				"additionalGids": nil,
+			},
+			"args": frm.Action.Entrypoint,
+			"env": func() (env []string) {
+				for k, v := range frm.Action.Env {
+					env = append(env, k+"="+v)
+				}
+				return
+			}(),
+			"cwd": frm.Action.Cwd,
 		},
-		"devpts": {
-			"type": "devpts",
-			"source": "devpts",
-			"options": [
-				"nosuid",
-				"noexec",
-				"newinstance",1
-				"ptmxmode=0666",
-				"mode=0620",
-				"gid=5"
-			]
+		"root": map[string]interface{}{
+			"path":     "rootfs",
+			"readonly": true,
 		},
-		"mqueue": {
-			"type": "mqueue",
-			"source": "mqueue",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev"
-			]
+		"hostname": "shell",
+		"mounts": []interface{}{
+			map[string]interface{}{
+				"name": "proc",
+				"path": "/proc",
+			},
 		},
-		"proc": {
-			"type": "proc",
-			"source": "proc",
-			"options": null
+		"linux": map[string]interface{}{
+			"capabilities": []interface{}{
+				"CAP_AUDIT_WRITE",
+				"CAP_KILL",
+			},
 		},
-		"shm": {
-			"type": "tmpfs",
-			"source": "shm",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev",
-				"mode=1777",
-				"size=65536k"
-			]
-		},
-		"sysfs": {
-			"type": "sysfs",
-			"source": "sysfs",
-			"options": [
-				"nosuid",
-				"noexec",
-				"nodev"
-			]
-		}
-	},
-	"hooks": {
-		"prestart": null,
-		"poststop": null
-	},
-	"linux": {
-		"uidMappings": null,
-		"gidMappings": null,
-		"rlimits": [
-			{
-				"type": "RLIMIT_NOFILE",
-				"hard": 1024,
-				"soft": 1024
-			}
-		],
-		"sysctl": null,
-		"resources": {
-			"disableOOMKiller": false,
-			"memory": {
-				"limit": 0,
-				"reservation": 0,
-				"swap": 0,
-				"kernel": 0,
-				"swappiness": -1
-			},
-			"cpu": {
-				"shares": 0,
-				"quota": 0,
-				"period": 0,
-				"realtimeRuntime": 0,
-				"realtimePeriod": 0,
-				"cpus": "",
-				"mems": ""
-			},
-			"pids": {
-				"limit": 0
-			},
-			"blockIO": {
-				"blkioWeight": 0,
-				"blkioLeafWeight": 0,
-				"blkioWeightDevice": null,
-				"blkioThrottleReadBpsDevice": null,
-				"blkioThrottleWriteBpsDevice": null,
-				"blkioThrottleReadIOPSDevice": null,
-				"blkioThrottleWriteIOPSDevice": null
-			},
-			"hugepageLimits": null,
-			"network": {
-				"classId": "",
-				"priorities": null
-			}
-		},
-		"cgroupsPath": "",
-		"namespaces": [
-			{
-				"type": "pid",
-				"path": ""
-			},
-			{
-				"type": "network",
-				"path": ""
-			},
-			{
-				"type": "ipc",
-				"path": ""
-			},
-			{
-				"type": "uts",
-				"path": ""
-			},
-			{
-				"type": "mount",
-				"path": ""
-			}
-		],
-		"devices": [
-			{
-				"path": "/dev/null",
-				"type": 99,
-				"major": 1,
-				"minor": 3,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			},
-			{
-				"path": "/dev/random",
-				"type": 99,
-				"major": 1,
-				"minor": 8,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			},
-			{
-				"path": "/dev/full",
-				"type": 99,
-				"major": 1,
-				"minor": 7,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			},
-			{
-				"path": "/dev/tty",
-				"type": 99,
-				"major": 5,
-				"minor": 0,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			},
-			{
-				"path": "/dev/zero",
-				"type": 99,
-				"major": 1,
-				"minor": 5,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			},
-			{
-				"path": "/dev/urandom",
-				"type": 99,
-				"major": 1,
-				"minor": 9,
-				"permissions": "rwm",
-				"fileMode": 438,
-				"uid": 0,
-				"gid": 0
-			}
-		],
-		"apparmorProfile": "",
-		"selinuxProcessLabel": "",
-		"seccomp": {
-			"defaultAction": "SCMP_ACT_ALLOW",
-			"syscalls": []
-		},
-		"rootfsPropagation": ""
 	}
-}`
+}
+
+func EmitRuncRuntimeStruct(_ def.Formula) interface{} {
+	return map[string]interface{}{
+		"mounts": map[string]interface{}{
+			"proc": map[string]interface{}{
+				"type":    "proc",
+				"source":  "proc",
+				"options": nil,
+			},
+		},
+		"linux": map[string]interface{}{
+			"resources": map[string]interface{}{},
+			"namespaces": []interface{}{
+				map[string]interface{}{
+					"type": "pid",
+					"path": "",
+				},
+				map[string]interface{}{
+					"type": "ipc",
+					"path": "",
+				},
+				map[string]interface{}{
+					"type": "uts",
+					"path": "",
+				},
+				map[string]interface{}{
+					"type": "mount",
+					"path": "",
+				},
+			},
+			"devices": []interface{}{
+				map[string]interface{}{
+					"path":        "/dev/null",
+					"type":        99,
+					"major":       1,
+					"minor":       3,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+				map[string]interface{}{
+					"path":        "/dev/random",
+					"type":        99,
+					"major":       1,
+					"minor":       8,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+				map[string]interface{}{
+					"path":        "/dev/full",
+					"type":        99,
+					"major":       1,
+					"minor":       7,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+				map[string]interface{}{
+					"path":        "/dev/tty",
+					"type":        99,
+					"major":       5,
+					"minor":       0,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+				map[string]interface{}{
+					"path":        "/dev/zero",
+					"type":        99,
+					"major":       1,
+					"minor":       5,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+				map[string]interface{}{
+					"path":        "/dev/urandom",
+					"type":        99,
+					"major":       1,
+					"minor":       9,
+					"permissions": "rwm",
+					"fileMode":    438,
+					"uid":         0,
+					"gid":         0,
+				},
+			},
+		},
+	}
+}

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -4,7 +4,7 @@ import (
 	"polydawn.net/repeatr/def"
 )
 
-func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
+func EmitRuncConfigStruct(frm def.Formula, job def.Job, rootPath string) interface{} {
 	return map[string]interface{}{
 		"version": "0.2.0",
 		"platform": map[string]interface{}{
@@ -31,7 +31,7 @@ func EmitRuncConfigStruct(frm def.Formula, rootPath string) interface{} {
 			"path":     rootPath,
 			"readonly": false,
 		},
-		"hostname": "shell",
+		"hostname": string(job.Id()),
 		"mounts": []interface{}{
 			map[string]interface{}{
 				"name": "proc",

--- a/executor/runc/runc_config.go
+++ b/executor/runc/runc_config.go
@@ -1,0 +1,283 @@
+package runc
+
+var confConfigTmpl = `{
+	"version": "0.1.0",
+	"platform": {
+		"os": "linux",
+		"arch": "amd64"
+	},
+	"process": {
+		"terminal": true,
+		"user": {
+			"uid": 0,
+			"gid": 0,
+			"additionalGids": null
+		},
+		"args": [
+			"sh"
+		],
+		"env": [
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=xterm"
+		],
+		"cwd": ""
+	},
+	"root": {
+		"path": "rootfs",
+		"readonly": true
+	},
+	"hostname": "shell",
+	"mounts": [
+		{
+			"name": "proc",
+			"path": "/proc"
+		},
+		{
+			"name": "dev",
+			"path": "/dev"
+		},
+		{
+			"name": "devpts",
+			"path": "/dev/pts"
+		},
+		{
+			"name": "shm",
+			"path": "/dev/shm"
+		},
+		{
+			"name": "mqueue",
+			"path": "/dev/mqueue"
+		},
+		{
+			"name": "sysfs",
+			"path": "/sys"
+		},
+		{
+			"name": "cgroup",
+			"path": "/sys/fs/cgroup"
+		}
+	],
+	"linux": {
+		"capabilities": [
+			"CAP_AUDIT_WRITE",
+			"CAP_KILL",
+			"CAP_NET_BIND_SERVICE"
+		]
+	}
+}`
+
+var confRuntimeTmpl = `{
+	"mounts": {
+		"cgroup": {
+			"type": "cgroup",
+			"source": "cgroup",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"relatime",
+				"ro"
+			]
+		},
+		"dev": {
+			"type": "tmpfs",
+			"source": "tmpfs",
+			"options": [
+				"nosuid",
+				"strictatime",
+				"mode=755",
+				"size=65536k"
+			]
+		},
+		"devpts": {
+			"type": "devpts",
+			"source": "devpts",
+			"options": [
+				"nosuid",
+				"noexec",
+				"newinstance",1
+				"ptmxmode=0666",
+				"mode=0620",
+				"gid=5"
+			]
+		},
+		"mqueue": {
+			"type": "mqueue",
+			"source": "mqueue",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		},
+		"proc": {
+			"type": "proc",
+			"source": "proc",
+			"options": null
+		},
+		"shm": {
+			"type": "tmpfs",
+			"source": "shm",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev",
+				"mode=1777",
+				"size=65536k"
+			]
+		},
+		"sysfs": {
+			"type": "sysfs",
+			"source": "sysfs",
+			"options": [
+				"nosuid",
+				"noexec",
+				"nodev"
+			]
+		}
+	},
+	"hooks": {
+		"prestart": null,
+		"poststop": null
+	},
+	"linux": {
+		"uidMappings": null,
+		"gidMappings": null,
+		"rlimits": [
+			{
+				"type": "RLIMIT_NOFILE",
+				"hard": 1024,
+				"soft": 1024
+			}
+		],
+		"sysctl": null,
+		"resources": {
+			"disableOOMKiller": false,
+			"memory": {
+				"limit": 0,
+				"reservation": 0,
+				"swap": 0,
+				"kernel": 0,
+				"swappiness": -1
+			},
+			"cpu": {
+				"shares": 0,
+				"quota": 0,
+				"period": 0,
+				"realtimeRuntime": 0,
+				"realtimePeriod": 0,
+				"cpus": "",
+				"mems": ""
+			},
+			"pids": {
+				"limit": 0
+			},
+			"blockIO": {
+				"blkioWeight": 0,
+				"blkioLeafWeight": 0,
+				"blkioWeightDevice": null,
+				"blkioThrottleReadBpsDevice": null,
+				"blkioThrottleWriteBpsDevice": null,
+				"blkioThrottleReadIOPSDevice": null,
+				"blkioThrottleWriteIOPSDevice": null
+			},
+			"hugepageLimits": null,
+			"network": {
+				"classId": "",
+				"priorities": null
+			}
+		},
+		"cgroupsPath": "",
+		"namespaces": [
+			{
+				"type": "pid",
+				"path": ""
+			},
+			{
+				"type": "network",
+				"path": ""
+			},
+			{
+				"type": "ipc",
+				"path": ""
+			},
+			{
+				"type": "uts",
+				"path": ""
+			},
+			{
+				"type": "mount",
+				"path": ""
+			}
+		],
+		"devices": [
+			{
+				"path": "/dev/null",
+				"type": 99,
+				"major": 1,
+				"minor": 3,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"path": "/dev/random",
+				"type": 99,
+				"major": 1,
+				"minor": 8,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"path": "/dev/full",
+				"type": 99,
+				"major": 1,
+				"minor": 7,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"path": "/dev/tty",
+				"type": 99,
+				"major": 5,
+				"minor": 0,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"path": "/dev/zero",
+				"type": 99,
+				"major": 1,
+				"minor": 5,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			},
+			{
+				"path": "/dev/urandom",
+				"type": 99,
+				"major": 1,
+				"minor": 9,
+				"permissions": "rwm",
+				"fileMode": 438,
+				"uid": 0,
+				"gid": 0
+			}
+		],
+		"apparmorProfile": "",
+		"selinuxProcessLabel": "",
+		"seccomp": {
+			"defaultAction": "SCMP_ACT_ALLOW",
+			"syscalls": []
+		},
+		"rootfsPropagation": ""
+	}
+}`

--- a/executor/runc/runc_config_test.go
+++ b/executor/runc/runc_config_test.go
@@ -1,0 +1,1 @@
+package runc

--- a/executor/runc/runc_config_test.go
+++ b/executor/runc/runc_config_test.go
@@ -1,1 +1,0 @@
-package runc

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -37,6 +37,7 @@ func (e *Executor) Configure(workspacePath string) {
 func (e *Executor) Start(f def.Formula, id def.JobID, stdin io.Reader, journal io.Writer) def.Job {
 	// TODO this function sig and its interface are long overdue for an aggressive refactor.
 	// - `journal` is Rong.  The streams mux should be accessible after this function's scope!
+	//   - either that or it's time to get cracking on saving the stream mux as an output
 	// - `journal` should still be a thing, but it should be a logger.
 	// - All these other values should move along in a `Job` struct
 	//   - `BasicJob` sorta started, but is drunk:
@@ -46,6 +47,7 @@ func (e *Executor) Start(f def.Formula, id def.JobID, stdin io.Reader, journal i
 	//   - The current `Job` interface is in the wrong package
 	// - almost all of the scopes in these functions is wrong
 	//   - they should be realigned until they actually assist the defers and cleanups
+	//     - e.g. withErrorCapture, withJobWorkPath, withFilesystems, etc
 
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 
@@ -174,6 +175,44 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 			panic(executor.UnknownError.Wrap(err))
 		}
 	}).Done()
+
+	// Proxy runc's logs out; also, detect errors and exit statuses from the stream.
+	go func() {
+		f, err := os.OpenFile(logPath, os.O_CREATE|os.O_RDONLY, 0644)
+		// TODO races child; doesn't matter, but probably easiest if we open a handle before exec'ing.
+		if err != nil {
+			panic(err)
+			// FIXME ... emit via chan?
+			// want to wait for exit after this, but also want to report immediately, but also not block
+			// probably need some seriously fancy selects here
+		}
+		defer f.Close()
+		// make a json decoder, right after swaddling the file in userland-interruptable reader;
+		//  obviously we don't want to stop watching the logs when we hit the end of the still-growing file.
+		dec := json.NewDecoder(streamer.NewTailReader(f))
+		// FIXME this needs to be closed by the exit code waiter... move out
+		for {
+			var logMsg map[string]string
+			err := dec.Decode(&logMsg)
+			if err != nil {
+				if err == io.EOF {
+					return
+				}
+				panic(err)
+			}
+			// remap
+			ctx := log15.Ctx{}
+			for k, v := range logMsg {
+				if k == "msg" {
+					continue
+				}
+				ctx[k] = v
+			}
+			// with runc, everything we hear is at least a warning.
+			journal.Warn(logMsg["msg"], ctx)
+			// TODO actually filtering the interesting structures and raising issues
+		}
+	}()
 
 	// Wait for the job to complete
 	result.ExitCode = proc.GetExitCode()

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -116,26 +116,28 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 	defer assembly.Teardown()
 
 	// Emit configs for runc.
+	runcConfigJsonPath := filepath.Join(jobPath, "config.json")
 	cfg := EmitRuncConfigStruct(formula)
 	buf, err := json.Marshal(cfg)
 	if err != nil {
 		panic(executor.UnknownError.Wrap(err))
 	}
-	ioutil.WriteFile(filepath.Join(jobPath, "config.json"), buf, 0600)
+	ioutil.WriteFile(runcConfigJsonPath, buf, 0600)
+	runcRuntimeJsonPath := filepath.Join(jobPath, "runtime.json")
 	cfg = EmitRuncRuntimeStruct(formula)
 	buf, err = json.Marshal(cfg)
 	if err != nil {
 		panic(executor.UnknownError.Wrap(err))
 	}
-	ioutil.WriteFile(filepath.Join(jobPath, "runtime.json"), buf, 0600)
+	ioutil.WriteFile(runcRuntimeJsonPath, buf, 0600)
 
 	// Prepare command to exec
 	args := []string{
 		"--root", filepath.Join(e.workspacePath, "shared"), // a tmpfs would be appropriate
 		"--log", logPath,
 		"start",
-		"--config-file", filepath.Join(jobPath, "config.json"),
-		"--runtime-file", filepath.Join(jobPath, "runtime.json"),
+		"--config-file", runcConfigJsonPath,
+		"--runtime-file", runcRuntimeJsonPath,
 	}
 	cmd := exec.Command("runc", args...)
 	cmd.Stdin = nil

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -35,6 +35,17 @@ func (e *Executor) Configure(workspacePath string) {
 }
 
 func (e *Executor) Start(f def.Formula, id def.JobID, stdin io.Reader, journal io.Writer) def.Job {
+	// TODO this function sig and its interface are long overdue for an aggressive refactor.
+	// - `journal` is Rong.  The streams mux should be accessible after this function's scope!
+	// - `journal` should still be a thing, but it should be a logger.
+	// - All these other values should move along in a `Job` struct
+	//   - `BasicJob` sorta started, but is drunk:
+	//      - if we're gonna have that, it's incomplete on the inputs
+	//      - for some reason it mixes in responsibility for waiting for some of the ouputs
+	//      - that use of channels and public fields is stupidly indefensive
+	//   - The current `Job` interface is in the wrong package
+	// - almost all of the scopes in these functions is wrong
+	//   - they should be realigned until they actually assist the defers and cleanups
 
 	// Prepare the forumla for execution on this host
 	def.ValidateAll(&f)
@@ -219,6 +230,7 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 
 	// Wait for the job to complete
 	result.ExitCode = proc.GetExitCode()
+	//runcLog.Close() // this could/should happen before PreserveOutputs.  see todo about fixing scopes.
 
 	// Save outputs
 	result.Outputs = util.PreserveOutputs(transmat, formula.Outputs, rootfsPath, journal)

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -133,7 +133,7 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 
 	// Emit configs for runc.
 	runcConfigJsonPath := filepath.Join(jobPath, "config.json")
-	cfg := EmitRuncConfigStruct(formula, rootfsPath)
+	cfg := EmitRuncConfigStruct(formula, job, rootfsPath)
 	buf, err := json.Marshal(cfg)
 	if err != nil {
 		panic(executor.UnknownError.Wrap(err))

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -117,7 +117,7 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 
 	// Emit configs for runc.
 	runcConfigJsonPath := filepath.Join(jobPath, "config.json")
-	cfg := EmitRuncConfigStruct(formula)
+	cfg := EmitRuncConfigStruct(formula, rootfsPath)
 	buf, err := json.Marshal(cfg)
 	if err != nil {
 		panic(executor.UnknownError.Wrap(err))

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -201,12 +201,15 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 				panic(err)
 			}
 			// remap
+			if _, ok := logMsg["msg"]; !ok {
+				logMsg["msg"] = ""
+			}
 			ctx := log15.Ctx{}
 			for k, v := range logMsg {
 				if k == "msg" {
 					continue
 				}
-				ctx[k] = v
+				ctx["runc-"+k] = v
 			}
 			// with runc, everything we hear is at least a warning.
 			journal.Warn(logMsg["msg"], ctx)

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -174,4 +174,15 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 	result.Outputs = util.PreserveOutputs(transmat, formula.Outputs, rootfsPath, journal)
 
 	// TODO : additional error detection of runc failure modes
+	// Okay, what do we know?
+	//  - They use logrus
+	//  - I've only seen warns and fatals so far, which is kinda amusing
+	//    - But I'm AOK with this: it means we can proxy those messages freely without noise issues
+	//  - INVESTIGATE: does logrus even *have* a mechanism to switch formats to something structural like log15 can?
+	//    - If so, this would still likely require moving a patch upstream in order to expose usefully
+	//      - And while I'm all about moving everyone forward together, that's probably going to get derailed into a spec discussion about lifecycle events, and that's great,
+	//        - but I want to use this before that even if it requires ducttape.
+	//      - Alternatively!  We *are* building runc from source already; maintaining a formula and patches together in-repo here would be totally reasonable.
+	//    - Yes!  It can accept a Formatter and there is a JSON Formatter.  No, there are no flags that currently do this.
+	//      - SetFormatter: we can call it.  Runc is currently only using the global logrus instance.
 }

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -17,6 +17,7 @@ import (
 	"polydawn.net/repeatr/executor/basicjob"
 	"polydawn.net/repeatr/executor/util"
 	"polydawn.net/repeatr/io"
+	"polydawn.net/repeatr/io/assets"
 	"polydawn.net/repeatr/lib/flak"
 	"polydawn.net/repeatr/lib/streamer"
 )
@@ -131,6 +132,9 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 	}
 	ioutil.WriteFile(runcRuntimeJsonPath, buf, 0600)
 
+	// Get handle to invokable runc plugin.
+	runcPath := filepath.Join(assets.Get("runc"), "bin/runc")
+
 	// Prepare command to exec
 	args := []string{
 		"--root", filepath.Join(e.workspacePath, "shared"), // a tmpfs would be appropriate
@@ -139,7 +143,7 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 		"--config-file", runcConfigJsonPath,
 		"--runtime-file", runcRuntimeJsonPath,
 	}
-	cmd := exec.Command("runc", args...)
+	cmd := exec.Command(runcPath, args...)
 	cmd.Stdin = nil
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -249,6 +249,8 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 				realError = executor.NoSuchCwdError.New("cannot set cwd to %q: no such file or directory", formula.Action.Cwd)
 			case "Container start failed: [8] System error: not a directory":
 				realError = executor.NoSuchCwdError.New("cannot set cwd to %q: not a directory", formula.Action.Cwd)
+			case "Container start failed: [8] System error: fork/exec /proc/self/exe: invalid argument":
+				realError = executor.TaskExecError.New("runc cannot operate in this environment!  %s", "fork/exec /proc/self/exe: invalid argument")
 			default:
 				// broader patterns required for some of these so we can ignore the vagaries of how the command name was quoted
 				if strings.HasPrefix(logMsg["msg"], "Container start failed: [8] System error: exec: ") {

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -1,0 +1,175 @@
+package runc
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/inconshreveable/log15"
+	"github.com/polydawn/gosh"
+	"github.com/spacemonkeygo/errors"
+	"github.com/spacemonkeygo/errors/try"
+
+	"polydawn.net/repeatr/def"
+	"polydawn.net/repeatr/executor"
+	"polydawn.net/repeatr/executor/basicjob"
+	"polydawn.net/repeatr/executor/util"
+	"polydawn.net/repeatr/io"
+	"polydawn.net/repeatr/lib/flak"
+	"polydawn.net/repeatr/lib/streamer"
+)
+
+// interface assertion
+var _ executor.Executor = &Executor{}
+
+type Executor struct {
+	workspacePath string
+}
+
+func (e *Executor) Configure(workspacePath string) {
+	e.workspacePath = workspacePath
+}
+
+func (e *Executor) Start(f def.Formula, id def.JobID, stdin io.Reader, journal io.Writer) def.Job {
+
+	// Prepare the forumla for execution on this host
+	def.ValidateAll(&f)
+
+	job := basicjob.New(id)
+	jobReady := make(chan struct{})
+
+	go func() {
+		// Run the formula in a temporary directory
+		flak.WithDir(func(dir string) {
+
+			// spool our output to a muxed stream
+			var strm streamer.Mux
+			strm = streamer.CborFileMux(filepath.Join(dir, "log"))
+			outS := strm.Appender(1)
+			errS := strm.Appender(2)
+			job.Streams = strm
+			defer func() {
+				// Regardless of how the job ends (or even if it fails the remaining setup), output streams must be terminated.
+				outS.Close()
+				errS.Close()
+			}()
+
+			// Job is ready to stream process output
+			close(jobReady)
+
+			// Set up a logger.  Tag all messages with this jobid.
+			logger := log15.New(log15.Ctx{"JobID": id})
+			logger.SetHandler(log15.StreamHandler(journal, log15.TerminalFormat()))
+
+			job.Result = e.Run(f, job, dir, stdin, outS, errS, logger)
+		}, e.workspacePath, "job", string(job.Id()))
+
+		// Directory is clean; job complete
+		close(job.WaitChan)
+	}()
+
+	<-jobReady
+	return job
+}
+
+// Executes a job, catching any panics.
+func (e *Executor) Run(f def.Formula, j def.Job, d string, stdin io.Reader, outS, errS io.WriteCloser, journal log15.Logger) def.JobResult {
+	r := def.JobResult{
+		ID:       j.Id(),
+		ExitCode: -1,
+	}
+
+	try.Do(func() {
+		e.Execute(f, j, d, &r, outS, errS, journal)
+	}).Catch(executor.Error, func(err *errors.Error) {
+		r.Error = err
+	}).Catch(integrity.Error, func(err *errors.Error) {
+		r.Error = err
+	}).CatchAll(func(err error) {
+		r.Error = executor.UnknownError.Wrap(err).(*errors.Error)
+	}).Done()
+
+	return r
+}
+
+// Execute a formula in a specified directory. MAY PANIC.
+func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, result *def.JobResult, stdout, stderr io.WriteCloser, journal log15.Logger) {
+	rootfsPath := filepath.Join(jobPath, "rootfs")
+	logPath := filepath.Join(jobPath, "runc-debug.log")
+
+	// Prepare inputs
+	transmat := util.DefaultTransmat()
+	inputArenas := util.ProvisionInputs(transmat, formula.Inputs, journal)
+	util.ProvisionOutputs(formula.Outputs, rootfsPath, journal)
+
+	// Assemble filesystem
+	assembly := util.AssembleFilesystem(
+		util.BestAssembler(),
+		rootfsPath,
+		formula.Inputs,
+		inputArenas,
+		formula.Action.Escapes.Mounts,
+		journal,
+	)
+	defer assembly.Teardown()
+
+	// Emit configs for runc.
+	cfg := EmitRuncConfigStruct(formula)
+	buf, err := json.Marshal(cfg)
+	if err != nil {
+		panic(executor.UnknownError.Wrap(err))
+	}
+	ioutil.WriteFile(filepath.Join(jobPath, "config.json"), buf, 0600)
+	cfg = EmitRuncRuntimeStruct(formula)
+	buf, err = json.Marshal(cfg)
+	if err != nil {
+		panic(executor.UnknownError.Wrap(err))
+	}
+	ioutil.WriteFile(filepath.Join(jobPath, "runtime.json"), buf, 0600)
+
+	// Prepare command to exec
+	args := []string{
+		"--root", filepath.Join(e.workspacePath, "shared"), // a tmpfs would be appropriate
+		"--log", logPath,
+		"start",
+		"--config-file", filepath.Join(jobPath, "config.json"),
+		"--runtime-file", filepath.Join(jobPath, "runtime.json"),
+	}
+	cmd := exec.Command("runc", args...)
+	cmd.Stdin = nil
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	// launch execution.
+	// transform gosh's typed errors to repeatr's hierarchical errors.
+	// this is... not untroubled code: since we're invoking a helper that's then
+	//  proxying the exec even further, most errors are fatal (the mapping here is
+	//   very different than in e.g. chroot executor, and provides much less meaning).
+	var proc gosh.Proc
+	try.Do(func() {
+		proc = gosh.ExecProcCmd(cmd)
+	}).CatchAll(func(err error) {
+		switch err.(type) {
+		case gosh.NoSuchCommandError:
+			panic(executor.ConfigError.New("runc binary is missing"))
+		case gosh.NoArgumentsError:
+			panic(executor.UnknownError.Wrap(err))
+		case gosh.NoSuchCwdError:
+			panic(executor.UnknownError.Wrap(err))
+		case gosh.ProcMonitorError:
+			panic(executor.TaskExecError.Wrap(err))
+		default:
+			panic(executor.UnknownError.Wrap(err))
+		}
+	}).Done()
+
+	// Wait for the job to complete
+	result.ExitCode = proc.GetExitCode()
+
+	// Save outputs
+	result.Outputs = util.PreserveOutputs(transmat, formula.Outputs, rootfsPath, journal)
+
+	// TODO : additional error detection of runc failure modes
+}

--- a/executor/runc/runc_executor.go
+++ b/executor/runc/runc_executor.go
@@ -198,7 +198,7 @@ func (e *Executor) Execute(formula def.Formula, job def.Job, jobPath string, res
 				if err == io.EOF {
 					return
 				}
-				panic(err)
+				panic(executor.TaskExecError.New("unparsable log from runc: %s", err))
 			}
 			// remap
 			if _, ok := logMsg["msg"]; !ok {

--- a/executor/runc/runc_executor_test.go
+++ b/executor/runc/runc_executor_test.go
@@ -13,6 +13,7 @@ func Test(t *testing.T) {
 	Convey("Spec Compliance: Runc Executor", t,
 		testutil.Requires(
 			testutil.RequiresRoot,
+			testutil.RequiresNamespaces,
 			testutil.WithTmpdir(func() {
 				execEng := &Executor{}
 				execEng.Configure("runc_workspace")

--- a/executor/runc/runc_executor_test.go
+++ b/executor/runc/runc_executor_test.go
@@ -1,0 +1,28 @@
+package runc
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"polydawn.net/repeatr/executor/tests"
+	"polydawn.net/repeatr/testutil"
+)
+
+func Test(t *testing.T) {
+	Convey("Spec Compliance: Runc Executor", t,
+		testutil.Requires(
+			testutil.RequiresRoot,
+			testutil.WithTmpdir(func() {
+				execEng := &Executor{}
+				execEng.Configure("runc_workspace")
+				So(os.Mkdir(execEng.workspacePath, 0755), ShouldBeNil)
+
+				tests.CheckBasicExecution(execEng)
+				tests.CheckFilesystemContainment(execEng)
+				tests.CheckPwdBehavior(execEng)
+				tests.CheckEnvBehavior(execEng)
+			}),
+		),
+	)
+}

--- a/executor/runc/runc_executor_test.go
+++ b/executor/runc/runc_executor_test.go
@@ -23,6 +23,7 @@ func Test(t *testing.T) {
 				tests.CheckFilesystemContainment(execEng)
 				tests.CheckPwdBehavior(execEng)
 				tests.CheckEnvBehavior(execEng)
+				tests.CheckHostnameBehavior(execEng)
 			}),
 		),
 	)

--- a/executor/tests/env_tests.go
+++ b/executor/tests/env_tests.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -13,7 +14,7 @@ import (
 )
 
 func CheckPwdBehavior(execEng executor.Executor) {
-	Convey("SPEC: Working directory should be contained", func() {
+	Convey("SPEC: Working directory should be contained", func(c C) {
 		formula := getBaseFormula()
 
 		Convey("The default pwd should be the root", func() {
@@ -27,7 +28,7 @@ func CheckPwdBehavior(execEng executor.Executor) {
 				Entrypoint: []string{"pwd"},
 			}
 
-			soExpectSuccessAndOutput(execEng, formula,
+			soExpectSuccessAndOutput(execEng, formula, testutil.Writer{c},
 				"/\n",
 			)
 		})
@@ -38,7 +39,7 @@ func CheckPwdBehavior(execEng executor.Executor) {
 				Entrypoint: []string{"pwd"},
 			}
 
-			soExpectSuccessAndOutput(execEng, formula,
+			soExpectSuccessAndOutput(execEng, formula, testutil.Writer{c},
 				"/usr\n",
 			)
 		})
@@ -49,7 +50,7 @@ func CheckPwdBehavior(execEng executor.Executor) {
 				Entrypoint: []string{"pwd"},
 			}
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldNotBeNil)
 			So(job.Wait().Error, testutil.ShouldBeErrorClass, executor.TaskExecError)
@@ -65,7 +66,7 @@ func CheckEnvBehavior(execEng executor.Executor) {
 	// NOTE the chroot executor currently uses `def.ValidateAll` which effectively *does not permit you to have an empty $PATH var*.
 	// we may decide to change that later -- but there's a correctness versus convenience battle there, and for now, we're going with convenience.
 
-	Convey("SPEC: Env vars should be contained", func() {
+	Convey("SPEC: Env vars should be contained", func(c C) {
 		formula := getBaseFormula()
 		formula.Action = def.Action{
 			Entrypoint: []string{"env"},
@@ -75,7 +76,7 @@ func CheckEnvBehavior(execEng executor.Executor) {
 			os.Setenv("REPEATR_TEST_KEY_1", "test value")
 			defer os.Unsetenv("REPEATR_TEST_KEY_1") // using unique strings per test anyway, because this is too scary
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldBeNil)
 			So(job.Wait().ExitCode, ShouldEqual, 0)
@@ -88,7 +89,7 @@ func CheckEnvBehavior(execEng executor.Executor) {
 			formula.Action.Env = make(map[string]string)
 			formula.Action.Env["REPEATR_TEST_KEY_2"] = "test value"
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldBeNil)
 			So(job.Wait().ExitCode, ShouldEqual, 0)
@@ -100,8 +101,8 @@ func CheckEnvBehavior(execEng executor.Executor) {
 	})
 }
 
-func soExpectSuccessAndOutput(execEng executor.Executor, formula def.Formula, output string) {
-	job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+func soExpectSuccessAndOutput(execEng executor.Executor, formula def.Formula, journal io.Writer, output string) {
+	job := execEng.Start(formula, def.JobID(guid.New()), nil, journal)
 	So(job, ShouldNotBeNil)
 	So(job.Wait().Error, ShouldBeNil)
 	So(job.Wait().ExitCode, ShouldEqual, 0)

--- a/executor/tests/env_tests.go
+++ b/executor/tests/env_tests.go
@@ -53,7 +53,23 @@ func CheckPwdBehavior(execEng executor.Executor) {
 			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldNotBeNil)
-			So(job.Wait().Error, testutil.ShouldBeErrorClass, executor.TaskExecError)
+			So(job.Wait().Error, testutil.ShouldBeErrorClass, executor.NoSuchCwdError)
+			So(job.Wait().ExitCode, ShouldEqual, -1)
+			msg, err := ioutil.ReadAll(job.OutputReader())
+			So(err, ShouldBeNil)
+			So(string(msg), ShouldEqual, "")
+		})
+
+		Convey("Setting a non-dir cwd should fail to launch", FailureContinues, func() {
+			formula.Action = def.Action{
+				Cwd:        "/bin/sh",
+				Entrypoint: []string{"pwd"},
+			}
+
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
+			So(job, ShouldNotBeNil)
+			So(job.Wait().Error, ShouldNotBeNil)
+			So(job.Wait().Error, testutil.ShouldBeErrorClass, executor.NoSuchCwdError)
 			So(job.Wait().ExitCode, ShouldEqual, -1)
 			msg, err := ioutil.ReadAll(job.OutputReader())
 			So(err, ShouldBeNil)

--- a/executor/tests/env_tests.go
+++ b/executor/tests/env_tests.go
@@ -117,6 +117,26 @@ func CheckEnvBehavior(execEng executor.Executor) {
 	})
 }
 
+func CheckHostnameBehavior(execEng executor.Executor) {
+	Convey("SPEC: Hostname should be job ID", func(c C) {
+		// note: considered just saying "not the host", but figured we
+		//  might as well pick a stance and stick with it.
+		formula := getBaseFormula()
+		formula.Action = def.Action{
+			Entrypoint: []string{"hostname"},
+		}
+
+		jobID := def.JobID(guid.New())
+		job := execEng.Start(formula, jobID, nil, testutil.Writer{c})
+		So(job, ShouldNotBeNil)
+		So(job.Wait().Error, ShouldBeNil)
+		So(job.Wait().ExitCode, ShouldEqual, 0)
+		msg, err := ioutil.ReadAll(job.OutputReader())
+		So(err, ShouldBeNil)
+		So(string(msg), ShouldEqual, string(jobID)+"\n")
+	})
+}
+
 func soExpectSuccessAndOutput(execEng executor.Executor, formula def.Formula, journal io.Writer, output string) {
 	job := execEng.Start(formula, def.JobID(guid.New()), nil, journal)
 	So(job, ShouldNotBeNil)

--- a/executor/tests/exec_tests.go
+++ b/executor/tests/exec_tests.go
@@ -25,7 +25,7 @@ import (
 	If any of these fail, most other parts of the specs will also fail.
 */
 func CheckBasicExecution(execEng executor.Executor) {
-	Convey("SPEC: Attempting launch with a rootfs that doesn't exist should error", func() {
+	Convey("SPEC: Attempting launch with a rootfs that doesn't exist should error", func(c C) {
 		formula := def.Formula{
 			Inputs: []def.Input{
 				{
@@ -41,7 +41,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 		}
 
 		Convey("We should get an error from the warehouse", func() {
-			result := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard).Wait()
+			result := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c}).Wait()
 			So(result.Error, testutil.ShouldBeErrorClass, integrity.WarehouseError)
 		})
 
@@ -49,7 +49,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 			formula.Action = def.Action{
 				Entrypoint: []string{"echo", "echococo"},
 			}
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldNotBeNil)
 			// Even though one should clearly also check the error status,
@@ -58,7 +58,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 		})
 	})
 
-	Convey("SPEC: Launching a command with a working rootfs should work", func() {
+	Convey("SPEC: Launching a command with a working rootfs should work", func(c C) {
 		formula := getBaseFormula()
 
 		Convey("The executor should be able to invoke echo", FailureContinues, func() {
@@ -66,7 +66,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 				Entrypoint: []string{"echo", "echococo"},
 			}
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			// note that we can read output concurrently.
 			// no need to wait for job done.
@@ -82,7 +82,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 				Entrypoint: []string{"sh", "-c", "exit 14"},
 			}
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldBeNil)
 			So(job.Wait().ExitCode, ShouldEqual, 14)
@@ -93,7 +93,7 @@ func CheckBasicExecution(execEng executor.Executor) {
 				Entrypoint: []string{"not a command"},
 			}
 
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job.Wait().Error, testutil.ShouldBeErrorClass, executor.NoSuchCommandError)
 			So(job.Wait().ExitCode, ShouldEqual, -1)
 			msg, err := ioutil.ReadAll(job.OutputReader())

--- a/executor/tests/fs_tests.go
+++ b/executor/tests/fs_tests.go
@@ -7,11 +7,12 @@ import (
 	"polydawn.net/repeatr/def"
 	"polydawn.net/repeatr/executor"
 	"polydawn.net/repeatr/lib/guid"
+	"polydawn.net/repeatr/testutil"
 	"polydawn.net/repeatr/testutil/filefixture"
 )
 
 func CheckFilesystemContainment(execEng executor.Executor) {
-	Convey("SPEC: Launching with multiple inputs should work", func() {
+	Convey("SPEC: Launching with multiple inputs should work", func(c C) {
 		formula := getBaseFormula()
 
 		Convey("Launch should succeed", func() {
@@ -27,7 +28,7 @@ func CheckFilesystemContainment(execEng executor.Executor) {
 			formula.Action = def.Action{
 				Entrypoint: []string{"/bin/true"},
 			}
-			job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+			job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 			So(job, ShouldNotBeNil)
 			So(job.Wait().Error, ShouldBeNil)
 			So(job.Wait().ExitCode, ShouldEqual, 0)
@@ -37,7 +38,7 @@ func CheckFilesystemContainment(execEng executor.Executor) {
 					Entrypoint: []string{"ls", "/data/test"},
 				}
 
-				job := execEng.Start(formula, def.JobID(guid.New()), nil, ioutil.Discard)
+				job := execEng.Start(formula, def.JobID(guid.New()), nil, testutil.Writer{c})
 				So(job, ShouldNotBeNil)
 				So(job.Wait().Error, ShouldBeNil)
 				So(job.Wait().ExitCode, ShouldEqual, 0)

--- a/io/assets/assets.go
+++ b/io/assets/assets.go
@@ -13,7 +13,7 @@ import (
 )
 
 var assets = map[string]integrity.CommitID{
-	"runc": integrity.CommitID("QATmJ0nliaN5K-4AX1hDEliA6nua-w91iVh0a6692oEyAfeedNKAs7_84JBcxfjO"),
+	"runc": integrity.CommitID("GWQ-0zuTIZDrY_noJMUb2zTSfxJJp9ldhfbQB7dRCQ-kzzaAoLVFFwWozoQJnHJf"),
 }
 
 /*

--- a/io/assets/errors.go
+++ b/io/assets/errors.go
@@ -1,0 +1,9 @@
+package assets
+
+import (
+	"github.com/spacemonkeygo/errors"
+
+	"polydawn.net/repeatr/io"
+)
+
+var ErrLoadingAsset *errors.ErrorClass = integrity.Error.NewClass("ErrLoadingAsset")

--- a/lib/streamer/tail.go
+++ b/lib/streamer/tail.go
@@ -1,0 +1,57 @@
+package streamer
+
+import (
+	"io"
+	"time"
+)
+
+var _ io.ReadCloser = &TailReader{}
+
+type TailReader struct {
+	r    io.Reader
+	quit chan struct{}
+}
+
+/*
+	Proxies another reader, disregarding EOFs and blocking instead until
+	the user closes.
+*/
+func NewTailReader(r io.Reader) *TailReader {
+	return &TailReader{
+		r:    r,
+		quit: make(chan struct{}),
+	}
+}
+
+func (r *TailReader) Read(msg []byte) (n int, err error) {
+	for n == 0 && err == nil {
+		n, err = r.r.Read(msg)
+		if err == io.EOF {
+			// We don't pass EOF up until we're commanded to be closed.
+			// This could be a "temporary" EOF and appends will still be incoming.
+			if n > 0 {
+				// If any bytes, pass them up immediately.
+				return n, nil
+			}
+			// We're effectively required to block here, because otherwise the reader may spin;
+			// this is not a clueful wait; but it does prevent pegging a core.
+			// Quite dumb in this case is also quite fool-proof.
+			err = nil
+			select {
+			case <-time.After(1 * time.Millisecond):
+			case <-r.quit:
+				return 0, io.EOF
+			}
+		}
+	}
+	// anything other than an eof, we have no behavioral changes to make; pass up.
+	return n, err
+}
+
+/*
+	Breaks any readers currently blocked.
+*/
+func (r *TailReader) Close() error {
+	close(r.quit)
+	return nil
+}

--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -1,0 +1,28 @@
+package testutil
+
+import (
+	"io"
+
+	"github.com/inconshreveable/log15"
+	"github.com/smartystreets/goconvey/convey"
+)
+
+func TestLogger(c convey.C) log15.Logger {
+	log := log15.New()
+	log.SetHandler(log15.StreamHandler(Writer{c}, log15.TerminalFormat()))
+	return log
+}
+
+var _ io.Writer = Writer{}
+
+/*
+	Wraps a goconvey context into an `io.Writer` so that you can
+	shovel logs at it.
+*/
+type Writer struct {
+	Convey convey.C
+}
+
+func (lw Writer) Write(msg []byte) (int, error) {
+	return lw.Convey.Print(string(msg))
+}

--- a/testutil/logging.go
+++ b/testutil/logging.go
@@ -18,6 +18,10 @@ var _ io.Writer = Writer{}
 /*
 	Wraps a goconvey context into an `io.Writer` so that you can
 	shovel logs at it.
+
+	... I really WANT goconvey to be clever about buffering this,
+	aligning it reasonably, and shutting it up unless something goes
+	wrong.  Alas, the terminal form of goconvey does none of these things.
 */
 type Writer struct {
 	Convey convey.C

--- a/testutil/misc.go
+++ b/testutil/misc.go
@@ -2,10 +2,6 @@ package testutil
 
 import (
 	"bytes"
-	"io"
-
-	"github.com/inconshreveable/log15"
-	"github.com/smartystreets/goconvey/convey"
 )
 
 /*
@@ -31,24 +27,4 @@ func AdditionalDescription(addtnlDesc ...string) string {
 	buf.WriteString(addtnlDesc[n-1])
 	buf.WriteRune(')')
 	return buf.String()
-}
-
-var _ io.Writer = Writer{}
-
-/*
-	Wraps a goconvey context into an `io.Writer` so that you can
-	shovel logs at it.
-*/
-type Writer struct {
-	Convey convey.C
-}
-
-func (lw Writer) Write(msg []byte) (int, error) {
-	return lw.Convey.Print(string(msg))
-}
-
-func TestLogger(c convey.C) log15.Logger {
-	log := log15.New()
-	log.SetHandler(log15.StreamHandler(Writer{c}, log15.TerminalFormat()))
-	return log
 }


### PR DESCRIPTION
Add a new executor plugin, this time backed by containers powered by runc!

Also, there's an asset management and bootstrapping tool wedged in there, which is used to obtain a well known version of a runc executable (e.g. exact same as we used when testing) in a safe integrity-guaranteed way.