### PR TITLE
Make travis more useful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - ./goad validate
   - ./goad install
   - ./lib/integration/assets.sh
+  - ./goad test # most will skip without root, but it's at least important that they correctly do so
   - sudo bash -c "export PATH=$PATH:$PWD/assets ; export GOROOT=$GOROOT ; ./goad test" # unescaped dollars are eval'd in an implicit first shell
   - sudo ./goad test-acceptance
 

--- a/goad
+++ b/goad
@@ -71,9 +71,15 @@ else
 		;;
 	test-acceptance)
 		[ -x "$GOPATH/bin/repeatr" ] || { echo "run 'goad install' first" 2>&1 ; exit 19; }
+		# demo and basic acceptance scenarios should run just about anywhere
 		./demo.sh -t
 		./lib/integration/runAll.sh
-		./repeat-thyself.sh
+		# repeat-thyself should usually run, but it has to sit out in travis PR-mode because of the synthetic commit which isn't actually cloneable
+		if [ "$TRAVIS" == 'true' -a "$TRAVIS_PULL_REQUEST" != 'false' ]; then
+			echo "skipping repeat-thyself test" 1>&2
+		else
+			./repeat-thyself.sh
+		fi
 		;;
 	install)
 		go generate "./..."

--- a/io/placer/assembler_test.go
+++ b/io/placer/assembler_test.go
@@ -285,56 +285,65 @@ func CheckAssemblerIsolatesSource(assemblerFn integrity.Assembler) {
 
 func CheckAssemblerBareMount(assemblerFn integrity.Assembler) {
 	Convey("Bare mounts continue to see changes to the source",
-		testutil.WithTmpdir(func() {
-			// make fixture
-			filefixture.Alpha.Create("./material/alpha")
-			// assemble
-			assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
-				{TargetPath: "/", SourcePath: "./material/alpha", Writable: false, BareMount: true},
-			})
-			defer assembly.Teardown()
-			// modify on the outside
-			f, err := os.OpenFile("./material/alpha/moar", os.O_CREATE, 0644)
-			defer f.Close()
-			So(err, ShouldBeNil)
-			// the outside should see it (obviously! just a sanity check)
-			So("./material/alpha/moar", testutil.ShouldBeFile, os.FileMode(0))
-			// the inside should see it
-			So("./assembled/moar", testutil.ShouldBeFile, os.FileMode(0))
-		}),
+		testutil.Requires(
+			testutil.RequiresRoot,
+			testutil.WithTmpdir(func() {
+				// make fixture
+				filefixture.Alpha.Create("./material/alpha")
+				// assemble
+				assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
+					{TargetPath: "/", SourcePath: "./material/alpha", Writable: false, BareMount: true},
+				})
+				defer assembly.Teardown()
+				// modify on the outside
+				f, err := os.OpenFile("./material/alpha/moar", os.O_CREATE, 0644)
+				defer f.Close()
+				So(err, ShouldBeNil)
+				// the outside should see it (obviously! just a sanity check)
+				So("./material/alpha/moar", testutil.ShouldBeFile, os.FileMode(0))
+				// the inside should see it
+				So("./assembled/moar", testutil.ShouldBeFile, os.FileMode(0))
+			}),
+		),
 	)
 	Convey("Writable bare mounts propagate changes to the source",
-		testutil.WithTmpdir(func() {
-			// make fixture
-			filefixture.Alpha.Create("./material/alpha")
-			// assemble
-			assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
-				{TargetPath: "/", SourcePath: "./material/alpha", Writable: true, BareMount: true},
-			})
-			defer assembly.Teardown()
-			// modify on the inside
-			f, err := os.OpenFile("./assembled/moar", os.O_CREATE, 0644)
-			defer f.Close()
-			So(err, ShouldBeNil)
-			// the inside should see it (obviously! just a sanity check)
-			So("./material/alpha/moar", testutil.ShouldBeFile, os.FileMode(0))
-			// the outside should see it
-			So("./assembled/moar", testutil.ShouldBeFile, os.FileMode(0))
-		}),
+		testutil.Requires(
+			testutil.RequiresRoot,
+			testutil.WithTmpdir(func() {
+				// make fixture
+				filefixture.Alpha.Create("./material/alpha")
+				// assemble
+				assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
+					{TargetPath: "/", SourcePath: "./material/alpha", Writable: true, BareMount: true},
+				})
+				defer assembly.Teardown()
+				// modify on the inside
+				f, err := os.OpenFile("./assembled/moar", os.O_CREATE, 0644)
+				defer f.Close()
+				So(err, ShouldBeNil)
+				// the inside should see it (obviously! just a sanity check)
+				So("./material/alpha/moar", testutil.ShouldBeFile, os.FileMode(0))
+				// the outside should see it
+				So("./assembled/moar", testutil.ShouldBeFile, os.FileMode(0))
+			}),
+		),
 	)
 	Convey("Readonly bare mounts reject writes",
-		testutil.WithTmpdir(func() {
-			// make fixture
-			filefixture.Alpha.Create("./material/alpha")
-			// assemble
-			assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
-				{TargetPath: "/", SourcePath: "./material/alpha", Writable: false, BareMount: true},
-			})
-			defer assembly.Teardown()
-			// modify on the inside should instantly error
-			f, err := os.OpenFile("./assembled/moar", os.O_CREATE, 0644)
-			defer f.Close()
-			So(err, ShouldNotBeNil)
-		}),
+		testutil.Requires(
+			testutil.RequiresRoot,
+			testutil.WithTmpdir(func() {
+				// make fixture
+				filefixture.Alpha.Create("./material/alpha")
+				// assemble
+				assembly := assemblerFn("./assembled", []integrity.AssemblyPart{
+					{TargetPath: "/", SourcePath: "./material/alpha", Writable: false, BareMount: true},
+				})
+				defer assembly.Teardown()
+				// modify on the inside should instantly error
+				f, err := os.OpenFile("./assembled/moar", os.O_CREATE, 0644)
+				defer f.Close()
+				So(err, ShouldNotBeNil)
+			}),
+		),
 	)
 }

--- a/io/transmat/git/git_transmat.go
+++ b/io/transmat/git/git_transmat.go
@@ -112,7 +112,7 @@ func (t *GitTransmat) Materialize(
 			} else {
 				log.Info("Warehouse unavailable, skipping",
 					"remote", uri,
-					"reason", pong,
+					"reason", pong.Message(),
 				)
 			}
 		}

--- a/io/transmat/git/git_transmat.go
+++ b/io/transmat/git/git_transmat.go
@@ -104,12 +104,16 @@ func (t *GitTransmat) Materialize(
 		var warehouse *Warehouse
 		for _, uri := range siloURIs {
 			wh := NewWarehouse(uri)
-			if wh.Ping() == nil {
+			pong := wh.Ping()
+			if pong == nil {
 				log.Info("git transmat: connected to remote warehouse", "remote", uri)
 				warehouse = wh
 				break
 			} else {
-				log.Info("Warehouse unavailable, skipping", "remote", uri)
+				log.Info("Warehouse unavailable, skipping",
+					"remote", uri,
+					"reason", pong,
+				)
 			}
 		}
 		if warehouse == nil {

--- a/io/transmat/git/git_warehouse.go
+++ b/io/transmat/git/git_warehouse.go
@@ -1,0 +1,65 @@
+package git
+
+import (
+	"github.com/polydawn/gosh"
+
+	"polydawn.net/repeatr/io"
+)
+
+/*
+	Refer to, interact with, and manage a warsehouse.
+
+	Since this is git we're talking about, this is basically references
+	to another git repo.
+*/
+type Warehouse struct {
+	url string
+}
+
+/*
+	Initialize a warehouse controller.
+
+	Note: parsing git URLs is *hard*.  This function is "best effort"
+	stuff and may not be able to error in all circumstances where the
+	git commands will error.  See `man gitremote-helpers` for one reason
+	this is the edge of a tarpit.  (This may improve as we do a better job
+	of pinning specific git versions and sandboxing their environment,
+	but at the moment, caveat emptor, and this is "PRs welcome" turf.)
+
+	May panic with:
+	  - Config Error: if the URI is unparsable or has an unsupported scheme.
+*/
+func NewWarehouse(coords integrity.SiloURI) *Warehouse {
+	wh := &Warehouse{}
+	// TODO we currently don't parse the URL at all, actually.
+	// `url.Parse` could be made to apply, but there's really nothing we
+	//  can explicitly blacklist, and we also don't internally need to
+	//   do any mode-switches here (git is already and always CAS).
+	wh.url = string(coords)
+	return wh
+}
+
+/*
+	Check if the warehouse exists and can be contacted.
+
+	Returns nil if contactable; if an error, the message will be
+	an end-user-meaningful description of why the warehouse is out of reach.
+*/
+func (wh *Warehouse) Ping() error {
+	// Shell out to git and ask it if it thinks there's a repo here.
+	// TODO this and all future shellouts does NOT SUFFICIENTLY ISOLATE either config or secret keeping yet.
+	// TODO there's no "--" in ls-remote, so... we should forbid things starting in "-", i guess?
+	//  or use "file://" religiously?  but no, bc ssh doesn't look like "ssh://" all the time... ugh, i do not want to write a git url parser
+	//   update: yeah, using "file://" religiously is not an option.  this actually takes a *different* path than `/non/protocol/prefixed`.  not significantly, but it may impact e.g. hardlinking, iiuc
+	// TODO someday go for the usability buff of parsing git errors into something more helpful
+	code := git.Bake(
+		"ls-remote", wh.url,
+		gosh.Opts{OkExit: []int{0, 128}},
+	).RunAndReport().GetExitCode()
+	// code 128 means no connection.
+	// any other code we currently panic on (with stderr attached, but it's still ugly).
+	if code != 0 {
+		return integrity.WarehouseUnavailableError.New("git remote unavailable")
+	}
+	return nil
+}

--- a/io/transmat/git/git_warehouse.go
+++ b/io/transmat/git/git_warehouse.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/polydawn/gosh"
+	"github.com/spacemonkeygo/errors"
 
 	"polydawn.net/repeatr/io"
 )
@@ -48,7 +49,7 @@ func NewWarehouse(coords integrity.SiloURI) *Warehouse {
 	Returns nil if contactable; if an error, the message will be
 	an end-user-meaningful description of why the warehouse is out of reach.
 */
-func (wh *Warehouse) Ping() error {
+func (wh *Warehouse) Ping() *errors.Error {
 	// Shell out to git and ask it if it thinks there's a repo here.
 	// TODO this and all future shellouts does NOT SUFFICIENTLY ISOLATE either config or secret keeping yet.
 	// TODO there's no "--" in ls-remote, so... we should forbid things starting in "-", i guess?
@@ -75,7 +76,7 @@ func (wh *Warehouse) Ping() error {
 		// Known values include:
 		//  - "'%s' does not appear to be a git repository"
 		//  - "attempt to fetch/clone from a shallow repository"
-		return integrity.WarehouseUnavailableError.New("git remote unavailable: %s", msg)
+		return integrity.WarehouseUnavailableError.New("git remote unavailable: %s", msg).(*errors.Error)
 	default:
 		// We don't recognize this.
 		panic(integrity.UnknownError.New("git exit code %d (stderr: %s)", code, errBuf.String()))


### PR DESCRIPTION
Travis should test non-root runs of the tests (most of them will skip themselves, but *that* should also be tested to work properly).

Also, we should not run repeat-thyself as an integration test in *some* travis builds, because their pattern of testing merge commits makes a synthetic commit that isn't readily fetchable.