### PR TITLE
Git overhaul -- fetch/checkout/submodule splits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,6 @@
 [submodule ".gopath/src/github.com/pkg/profile"]
 	path = .gopath/src/github.com/pkg/profile
 	url = https://github.com/pkg/profile
+[submodule ".gopath/src/github.com/vaughan0/go-ini"]
+	path = .gopath/src/github.com/vaughan0/go-ini
+	url = https://github.com/vaughan0/go-ini.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 recent /// not yet released
 ---------------------------
 
-- *your changes here!*
-- Feature: `repeatr run` now has a `--serialize` (or `-s`) flag that serializes all output and writes it to stdout. 
+- *your changes here!* 
+- Feature: Massive overhaul to the git transmat, which should massively increase efficiency and successful caching.
+  - Submodules are now cached: if you have a parent project move to a new commit, but keep all the same submodule versions, previously repeatr was oblivious; now, it's a fast 100% cache hit.
+  - Git data objects are now cached: fetches are incremental when using the same remote repos.
+  - Slight change: ".git" files in submodule paths no longer leak into the container's sight.  This shouldn't affect you unless you had output configurations exporting filesystems including such files.
+- Feature: `repeatr run` now has a `--serialize` (or `-s`) flag that serializes all output and writes it to stdout.
 - Internal: Added "exercise" script, which takes a final repeatr binary through the full cycle of major commands; useful for full validation on host environments.
 - Bugfix: Respect output filter configuration properly again!  This was broken in v0.12 and v0.13.
 - Bugfix: Bubble up errors from the AUFS placer correctly when mount fails!

--- a/core/executor/util/capabilities.go
+++ b/core/executor/util/capabilities.go
@@ -41,15 +41,12 @@ func DefaultTransmat() rio.Transmat {
 	fileCacher := cachedir.New(filepath.Join(workDir, "filecacher"), map[rio.TransmatKind]rio.TransmatFactory{
 		rio.TransmatKind("file"): file.New,
 	})
-	gitCacher := cachedir.New(filepath.Join(workDir, "dircacher-git"), map[rio.TransmatKind]rio.TransmatFactory{
-		rio.TransmatKind("git"): git.New,
-	})
 	universalTransmat := dispatch.New(map[rio.TransmatKind]rio.Transmat{
 		rio.TransmatKind("dir"):  dirCacher,
 		rio.TransmatKind("tar"):  dirCacher,
 		rio.TransmatKind("s3"):   dirCacher,
 		rio.TransmatKind("file"): fileCacher,
-		rio.TransmatKind("git"):  gitCacher,
+		rio.TransmatKind("git"):  git.New(filepath.Join(workDir, "git")),
 	})
 	return universalTransmat
 }

--- a/rio/transmat/impl/git/git_cmd.go
+++ b/rio/transmat/impl/git/git_cmd.go
@@ -1,0 +1,54 @@
+package git
+
+import "github.com/polydawn/gosh"
+
+func bakeGitDir(cmd gosh.Command, gitDir string) gosh.Command {
+	return cmd.Bake(
+		gosh.Opts{Env: map[string]string{
+			"GIT_DIR": gitDir,
+		}},
+	)
+}
+
+func bakeCheckoutDir(cmd gosh.Command, workDir string) gosh.Command {
+	return cmd.Bake(gosh.Opts{
+		Env: map[string]string{"GIT_WORK_TREE": workDir},
+		Cwd: workDir,
+	})
+}
+
+const (
+	git_uid = 1000
+	git_gid = 1000
+)
+
+var git gosh.Command = gosh.Gosh(
+	"git",
+	gosh.NullIO,
+	gosh.Opts{
+		Env: map[string]string{
+			"GIT_CONFIG_NOSYSTEM": "true",
+			"HOME":                "/dev/null",
+			"GIT_ASKPASS":         "/bin/true",
+		},
+		// We would *LOVE* to uncomment this block and drop privs.
+		// However, it's currently practically un-supportable: git running
+		// on a host that doesn't contain a username mapped to this uid
+		// will error on launch -- yep, it's one of *those* programs
+		// (at least as of 1.9.1; more recent upstreams *may* have patched it;
+		// haven't tested exhaustively yet.)
+		// To address this, we'd either need containerized-git (which may
+		// limit portability in some other undesirable fashions; ideally
+		// transmats should work without such heavy weaponry), or distributing
+		// a reference a particular (and likely patched) version of git.
+		// ----------------------------------------------------------------
+		//	Launcher: gosh.ExecCustomizingLauncher(func(cmd *exec.Cmd) {
+		//		cmd.SysProcAttr = &syscall.SysProcAttr{
+		//			Credential: &syscall.Credential{
+		//				Uid: uint32(git_uid),
+		//				Gid: uint32(git_gid),
+		//			},
+		//		}
+		//	}),
+	},
+)

--- a/rio/transmat/impl/git/git_internals.go
+++ b/rio/transmat/impl/git/git_internals.go
@@ -1,0 +1,190 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/inconshreveable/log15"
+	"github.com/polydawn/gosh"
+	"github.com/vaughan0/go-ini"
+
+	"go.polydawn.net/repeatr/rio"
+)
+
+/*
+	Does a fetch of all objects covered by the usual refs (aka branches and tags)
+	into the specified git dir.
+
+	Maps the remotes as their escaped url, so you can pile multiple remotes
+	into one repo and never fuss with collision issues.
+*/
+func yank(log log15.Logger, gitDir string, remoteURL string) {
+	// Mkdir.  (Fine if exists.)
+	if err := os.Mkdir(gitDir, 0755); err != nil && !os.IsExist(err) {
+		panic(err)
+	}
+	// Template out command with the right paths set.
+	git := bakeGitDir(git, gitDir)
+	// Init (is idempotent).
+	git.Bake("init", "--bare").RunAndReport()
+	// Fetch.
+	log.Info("git transmat: object fetch starting",
+		"remote", remoteURL,
+	)
+	git.Bake(
+		"fetch", "--",
+		remoteURL,
+		"+refs/heads/*:refs/remotes/"+slugifyRemote(remoteURL)+"/*",
+	).RunAndReport()
+	log.Info("git: object fetch complete",
+		"remote", remoteURL,
+	)
+}
+
+func checkout(log log15.Logger, destPath string, commitHash string, gitDir string) {
+	// Template out command with the right paths set.
+	git := bakeGitDir(git, gitDir)
+	git = bakeCheckoutDir(git, destPath)
+	// Checkout.
+	buf := &bytes.Buffer{}
+	p := git.Bake(
+		"checkout", "-f", commitHash,
+		gosh.Opts{
+			OkExit: gosh.AnyExit,
+			Err:    buf,
+			Out:    buf,
+		},
+	).Run()
+	if bytes.HasPrefix(buf.Bytes(), []byte("fatal: reference is not a tree: ")) {
+		panic(rio.DataDNE.New("hash %q not found in this repo", commitHash))
+	}
+	if p.GetExitCode() != 0 {
+		// catchall.
+		// this formatting is *terrible*, but we don't have a good formatter for using datakeys, either, so.
+		// (blowing past this without too much fuss because we're going to switch error libraries later and it's going to fix this better.)
+		panic(Error.New("git checkout failed.  git output:\n%s", buf.String()))
+	}
+}
+
+type submodule struct {
+	url  string
+	path string
+	hash string
+	// the config file includes a name, too, but we really have no use for it.
+}
+
+/*
+	Greatly comparable with the `module_list` function you might find
+	in "git//git-submodule.sh"... with less perl.
+
+	The returned structures only have `path` and `hash` set.
+	Use "applyGitmodulesUrls" to get the rest.
+*/
+func listSubmodules(commitHash string, gitDir string) []submodule {
+	// Template out command with the right paths set.
+	git := bakeGitDir(git, gitDir)
+	// Get stream of file info.
+	// We only want the gitlink ones, but there's no way to ask that ('-d' helps narrow it down to exclude files at least though).
+	trees := bufio.NewScanner(bytes.NewBufferString(git.Bake(
+		"ls-tree",
+		"-rdz",
+		"--", commitHash,
+	).Output()))
+	trees.Split(func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if atEOF && len(data) == 0 {
+			return 0, nil, nil
+		}
+		if i := bytes.IndexByte(data, 0); i >= 0 {
+			// We have a full null-terminated line.
+			return i + 1, data[0:i], nil
+		}
+		// If we're at EOF, we have a final, non-terminated line. Return it.
+		if atEOF {
+			return len(data), data, nil
+		}
+		// Request more data.
+		return 0, nil, nil
+	})
+	// Parse!
+	// Output format is "<mode> SP <type> SP <object> TAB <file>"
+	submods := make([]submodule, 0)
+	for trees.Scan() {
+		row := trees.Text()
+		if row[0:6] != "160000" {
+			continue
+		}
+		itab := strings.Index(row, "\t")
+		if itab < 0 {
+			panic(Error.New("git ls-tree IO failed: row must have tab"))
+		}
+		hunks := strings.Split(row[0:itab], " ")
+		if len(hunks) != 3 {
+			panic(Error.New("git ls-tree IO failed: row must have four hunks"))
+		}
+		submods = append(submods, submodule{
+			hash: hunks[2],
+			path: row[itab+1:],
+		})
+	}
+	if err := trees.Err(); err != nil {
+		panic(Error.New("git ls-tree IO failed: %s", err))
+	}
+	return submods
+}
+
+func applyGitmodulesUrls(commitHash string, gitDir string, submodules []submodule) []submodule {
+	// git config -f .gitmodules --get-regexp '^submodule\..*\.path$'
+	submconf, err := ini.Load(grabFile(commitHash, ".gitmodules", gitDir))
+	if err != nil {
+		panic(Error.New(".gitmodules file does not parse: %s", err))
+	}
+	for secName, section := range submconf {
+		// So this is fun to parse.
+		// As long as it's under the "submodule" group, we'll listen.
+		// Git's concept of the name for these sections isn't standard INI;
+		// on the other hand, we fortunately *don't care*:
+		// the names of these sections are potentially user specified and generally not our concern.
+		// We do a join of the path sections to where we found gitlinks;
+		// and that correctly answers all the questions we're concerned with.
+		if !strings.HasPrefix(secName, "submodule \"") {
+			continue
+		}
+		pth, ok := section["path"]
+		if !ok {
+			continue
+		}
+		url, ok := section["url"]
+		if !ok {
+			continue
+		}
+		for i, v := range submodules {
+			if v.path == pth {
+				submodules[i].url = url
+				break
+			}
+		}
+	}
+	return submodules
+}
+
+func grabFile(commitHash string, filePath string, gitDir string) (buf io.Reader) {
+	buf = &bytes.Buffer{}
+	// we punt pretty hard on errors:
+	//  if something goes wrong, we'll just presume there's no such file,
+	//  and return a empty stream.
+	defer func() {
+		recover()
+	}()
+	bakeGitDir(git, gitDir).Bake("cat-file", "blob",
+		commitHash+":"+filePath,
+		gosh.Opts{
+			In:  nil,
+			Out: buf,
+			Err: nil,
+		},
+	).Run()
+	return
+}

--- a/rio/transmat/impl/git/git_transmat.go
+++ b/rio/transmat/impl/git/git_transmat.go
@@ -144,8 +144,12 @@ func (t *GitTransmat) Materialize(
 		submodules = applyGitmodulesUrls(string(dataHash), gitDirPath, submodules)
 		func() {
 			started := time.Now()
-			// TODO ideally this would be smart enough to skip if we have hash cached. -- general problem with yank now actually
 			for _, subm := range submodules {
+				// Skip yank if we have the full checkout cached already.
+				if _, err := os.Stat(t.workArea.getNosubchFinalPath(subm.hash)); err == nil {
+					continue
+				}
+				// Okay, we need more stuff.  Fetch away.
 				yank(
 					log.New("submhash", subm.hash),
 					t.workArea.gitDirPath(subm.url),

--- a/rio/transmat/impl/git/git_transmat.go
+++ b/rio/transmat/impl/git/git_transmat.go
@@ -81,6 +81,14 @@ func (t *GitTransmat) Materialize(
 			panic(errors.ProgrammerError.New("This transmat supports definitions of type %q, not %q", Kind, kind))
 		}
 
+		// Short circut out if we have the whole hash cached.
+		finalPath := t.workArea.getFullchFinalPath(string(dataHash))
+		if _, err := os.Stat(finalPath); err == nil {
+			arena.workDirPath = finalPath
+			arena.hash = dataHash
+			return
+		}
+
 		// Emit git version.
 		// Until we get a reasonably static version linked&contained, this is going to be an ongoing source of potential trouble.
 		gitv := git.Bake("version").CombinedOutput()

--- a/rio/transmat/impl/git/git_transmat.go
+++ b/rio/transmat/impl/git/git_transmat.go
@@ -139,7 +139,7 @@ func (t *GitTransmat) Materialize(
 			// TODO ideally this would be smart enough to skip if we have hash cached. -- general problem with yank now actually
 			for _, subm := range submodules {
 				yank(
-					log,
+					log.New("submhash", subm.hash),
 					t.workArea.gitDirPath(subm.url),
 					subm.url,
 				)
@@ -177,7 +177,7 @@ func (t *GitTransmat) Materialize(
 				pth := t.workArea.makeNosubchTempPath(subm.hash)
 				defer os.RemoveAll(pth)
 				checkout(
-					log,
+					log.New("submhash", subm.hash),
 					pth,
 					subm.hash,
 					t.workArea.gitDirPath(subm.url),

--- a/rio/transmat/impl/git/git_transmat.go
+++ b/rio/transmat/impl/git/git_transmat.go
@@ -196,6 +196,12 @@ func (t *GitTransmat) Materialize(
 		func() {
 			started := time.Now()
 			for _, subm := range submodules {
+				// Skip if the cache dir already exists.
+				if _, err := os.Stat(t.workArea.getNosubchFinalPath(subm.hash)); err == nil {
+					continue
+				}
+				// Checkout into tmpdir, move it into place when done,
+				//  and remove the tempdir afterwards (if the move failed).
 				pth := t.workArea.makeNosubchTempPath(subm.hash)
 				defer os.RemoveAll(pth)
 				checkout(

--- a/rio/transmat/impl/git/git_transmat.go
+++ b/rio/transmat/impl/git/git_transmat.go
@@ -125,6 +125,11 @@ func (t *GitTransmat) Materialize(
 
 		// Fetch objects.
 		func() {
+			// Skip yank if the gitDir should have the objects already.
+			if hasCommit(string(dataHash), gitDirPath) {
+				return
+			}
+			// Okay, we need more stuff.  Fetch away.
 			started := time.Now()
 			yank(
 				log,
@@ -149,10 +154,15 @@ func (t *GitTransmat) Materialize(
 				if _, err := os.Stat(t.workArea.getNosubchFinalPath(subm.hash)); err == nil {
 					continue
 				}
+				// Skip yank if the gitDir should have the objects already.
+				gitDir := t.workArea.gitDirPath(subm.url)
+				if hasCommit(subm.hash, gitDir) {
+					continue
+				}
 				// Okay, we need more stuff.  Fetch away.
 				yank(
 					log.New("submhash", subm.hash),
-					t.workArea.gitDirPath(subm.url),
+					gitDir,
 					subm.url,
 				)
 			}

--- a/rio/transmat/impl/git/git_uri_parsing.go
+++ b/rio/transmat/impl/git/git_uri_parsing.go
@@ -1,4 +1,0 @@
-package git
-
-// actually... is there much point, beyond just shelling out to git?
-// we could do our own validation, but let's... not; i don't want a swiss cheese api.

--- a/rio/transmat/impl/git/git_utils.go
+++ b/rio/transmat/impl/git/git_utils.go
@@ -1,0 +1,27 @@
+package git
+
+import (
+	"encoding/hex"
+	"net/url"
+
+	"go.polydawn.net/repeatr/rio"
+)
+
+func mustBeFullHash(hash rio.CommitID) {
+	if len(hash) != 40 {
+		panic("gimme the whole thing")
+	}
+	if _, err := hex.DecodeString(string(hash)); err != nil {
+		panic("git commit hashes are hex strings")
+	}
+}
+
+/*
+	Return a string that's safe to use as a dir name.
+
+	Uses URL query escaping so it remains roughly readable.
+	Does not attempt any URL normalization.
+*/
+func slugifyRemote(remoteURL string) string {
+	return url.QueryEscape(remoteURL)
+}

--- a/rio/transmat/impl/git/git_workarea.go
+++ b/rio/transmat/impl/git/git_workarea.go
@@ -1,0 +1,62 @@
+package git
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"go.polydawn.net/repeatr/rio"
+)
+
+func mustDir(pth string) {
+	if err := os.MkdirAll(pth, 0755); err != nil {
+		panic(rio.TransmatError.New("Unable to set up workspace: %s", err))
+	}
+}
+
+type workArea struct {
+	fullCheckouts  string
+	nosubCheckouts string
+	gitDirs        string
+}
+
+func (wa workArea) gitDirPath(repoURL string) string {
+	return filepath.Join(wa.gitDirs, slugifyRemote(repoURL))
+}
+
+func (wa workArea) makeFullchTempPath(commitHash string) string {
+	pth, err := ioutil.TempDir(wa.fullCheckouts, commitHash+"-")
+	if err != nil {
+		panic(rio.TransmatError.New("Unable to set up tempdir: %s", err))
+	}
+	return pth
+}
+
+func (wa workArea) getFullchFinalPath(commitHash string) string {
+	return filepath.Join(wa.fullCheckouts, commitHash)
+}
+
+func (wa workArea) makeNosubchTempPath(commitHash string) string {
+	pth, err := ioutil.TempDir(wa.nosubCheckouts, commitHash+"-")
+	if err != nil {
+		panic(rio.TransmatError.New("Unable to set up tempdir: %s", err))
+	}
+	return pth
+}
+
+func (wa workArea) getNosubchFinalPath(commitHash string) string {
+	return filepath.Join(wa.nosubCheckouts, commitHash)
+}
+
+func moveOrShrug(from string, to string) {
+	err := os.Rename(from, to)
+	if err != nil {
+		if err2, ok := err.(*os.LinkError); ok &&
+			err2.Err == syscall.EBUSY || err2.Err == syscall.ENOTEMPTY {
+			// oh, fine.  somebody raced us to it.  we believe in them: just return.
+			return
+		}
+		panic(rio.TransmatError.New("Error commiting %q into cache: %s", from, err))
+	}
+}


### PR DESCRIPTION
Massive overhaul to the git transmat, which should increase efficiency and successful caching.

- Submodules are now cached: if you have a parent project move to a new commit, but keep all the same submodule versions, previously repeatr was oblivious; now, it's a fast 100% cache hit.
- Git data objects are now cached: fetches are incremental when using the same remote repos.
- Slight change: ".git" files in submodule paths no longer leak into the container's sight.  This shouldn't affect you unless you had output configurations exporting filesystems including such files.
 