### PR TITLE
Assembler file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ recent /// not yet released
 ---------------------------
 
 - *your changes here!*
+- Feature: the filesystem assembly now supports files as well as directories -- meaning the "file" transmat can be used in formulas, as can bind mounts of individual files from the host.
 
 
 v0.14 -- 72b19be26bbac56c9d1dc418a01bfe0b09a9363c -- 2017 Jan 17

--- a/rio/placer/assembler.go
+++ b/rio/placer/assembler.go
@@ -25,7 +25,7 @@ func (a defaultAssembler) Assemble(basePath string, parts []rio.AssemblyPart) ri
 	housekeeping := &defaultAssembly{}
 	for _, part := range parts {
 		destBasePath := filepath.Join(basePath, part.TargetPath)
-		if err := fs.MkdirAll(destBasePath); err != nil {
+		if err := fs.MkdirAll(filepath.Dir(destBasePath)); err != nil {
 			panic(meep.Meep(
 				&rio.ErrAssembly{System: "assembler"},
 				meep.Cause(err),

--- a/rio/placer/impl/aufs/aufsPlacer.go
+++ b/rio/placer/impl/aufs/aufsPlacer.go
@@ -14,6 +14,7 @@ import (
 	"go.polydawn.net/repeatr/lib/fs"
 	"go.polydawn.net/repeatr/rio"
 	"go.polydawn.net/repeatr/rio/placer/impl/bind"
+	"go.polydawn.net/repeatr/rio/placer/impl/copy"
 )
 
 func NewAufsPlacer(workPath string) rio.Placer {
@@ -42,8 +43,12 @@ func NewAufsPlacer(workPath string) rio.Placer {
 			return bind.BindPlacer(srcBasePath, destBasePath, writable, bareMount)
 		}
 		// ok, we really have to work.  validate params.
-		mustBeDir(sys, srcBasePath, "srcPath")
-		mustBeDir(sys, destBasePath, "destPath")
+		// if it's a file mount, aufs doesn't apply, so we have to shell out to copy.
+		wantMode := getSrcMode(srcBasePath, sys)
+		if wantMode == 0 {
+			return copy.CopyingPlacer(srcBasePath, destBasePath, writable, bareMount)
+		}
+		mkDest(destBasePath, wantMode, sys)
 		// make work dir for the overlay layer
 		layerPath, err := ioutil.TempDir(workPath, "layer-")
 		if err != nil {
@@ -70,6 +75,73 @@ func NewAufsPlacer(workPath string) rio.Placer {
 			landingPath: destBasePath,
 		}
 	}
+}
+
+func getSrcMode(srcBasePath string, logLabel string) os.FileMode {
+	srcBaseStat, err := os.Stat(srcBasePath)
+	if err != nil {
+		panic(meep.Meep(
+			&rio.ErrAssembly{System: logLabel, Path: "srcPath"},
+			meep.Cause(err),
+		))
+	}
+	mode := srcBaseStat.Mode() & os.ModeType
+	switch mode {
+	case os.ModeDir, 0:
+		return mode
+	default:
+		panic(meep.Meep(
+			&rio.ErrAssembly{System: logLabel, Path: "srcPath"},
+			meep.Cause(fmt.Errorf("source may only be dir or plain file")),
+		))
+	}
+}
+
+func mkDest(destBasePath string, wantMode os.FileMode, logLabel string) {
+	// Handle all the cases for existing things at destination.
+	destBaseStat, err := os.Stat(destBasePath)
+	if err == nil {
+		// If exists and wrong type, ErrAssembly.
+		if destBaseStat.Mode()&os.ModeType != wantMode {
+			panic(meep.Meep(
+				&rio.ErrAssembly{System: logLabel, Path: "destPath"},
+				meep.Cause(fmt.Errorf("already exists and is different type than source")),
+			))
+		}
+		// If exists and right type, exit early.
+		return
+	}
+	// If it doesn't exist, that's fine; any other error, ErrAssembly.
+	if !os.IsNotExist(err) {
+		panic(meep.Meep(
+			&rio.ErrAssembly{System: logLabel, Path: "destPath"},
+			meep.Cause(err),
+		))
+	}
+
+	// If we made it this far: dest doesn't exist yet.
+	// Capture the parent dir mtime, because we're about to disrupt it.
+
+	// Make the dest node, matching type of the source.
+	// The perms don't matter; will be shadowed.
+	// We assume the parent dirs are all in place because you're almost
+	// certainly using this as part of an assembler.
+	fs.WithMtimeRepair(filepath.Dir(destBasePath), func() {
+		switch wantMode {
+		case os.ModeDir:
+			err = os.Mkdir(destBasePath, 0644)
+		case 0:
+			var f *os.File
+			f, err = os.OpenFile(destBasePath, os.O_CREATE, 0644)
+			f.Close()
+		}
+		if err != nil {
+			panic(meep.Meep(
+				&rio.ErrAssembly{System: logLabel, Path: "destPath"},
+				meep.Cause(err),
+			))
+		}
+	})
 }
 
 type aufsEmplacement struct {

--- a/rio/placer/impl/copy/copyingPlacer.go
+++ b/rio/placer/impl/copy/copyingPlacer.go
@@ -90,8 +90,8 @@ func CopyingPlacer(srcBasePath, destBasePath string, _ bool, bareMount bool) rio
 		fs.PlaceFile(destBasePath, hdr, body)
 	default:
 		panic(meep.Meep(
-			&rio.ErrAssembly{System: sys, Path: "destPath"},
-			meep.Cause(fmt.Errorf("destination may only be dir or plain file")),
+			&rio.ErrAssembly{System: sys, Path: "srcPath"},
+			meep.Cause(fmt.Errorf("source may only be dir or plain file")),
 		))
 	}
 	// walk and copy

--- a/rio/placer/impl/copy/copyingPlacer.go
+++ b/rio/placer/impl/copy/copyingPlacer.go
@@ -52,9 +52,8 @@ func CopyingPlacer(srcBasePath, destBasePath string, _ bool, bareMount bool) rio
 		)
 	}
 	// remove any files already here (to emulate behavior like an overlapping mount)
-	// also, reject any destinations of the wrong type
-	typ := srcBaseStat.Mode() & os.ModeType
-	switch typ {
+	srcType := srcBaseStat.Mode() & os.ModeType
+	switch srcType {
 	case os.ModeDir:
 		if !os.IsNotExist(err) {
 			// can't take the easy route and just `os.RemoveAll(destBasePath)`
@@ -84,10 +83,13 @@ func CopyingPlacer(srcBasePath, destBasePath string, _ bool, bareMount bool) rio
 			}
 		}
 	case 0:
-		// Files: easier.
+		// Files: much easier path, because we can simply overwrite in place.
 		hdr, body := fs.ScanFile(srcBasePath, "", srcBaseStat)
 		defer body.Close()
-		fs.PlaceFile(destBasePath, hdr, body)
+		fs.WithMtimeRepair(filepath.Dir(destBasePath), func() {
+			fs.PlaceFile(destBasePath, hdr, body)
+		})
+		return copyEmplacement{path: destBasePath}
 	default:
 		panic(meep.Meep(
 			&rio.ErrAssembly{System: sys, Path: "srcPath"},
@@ -95,34 +97,36 @@ func CopyingPlacer(srcBasePath, destBasePath string, _ bool, bareMount bool) rio
 		))
 	}
 	// walk and copy
-	preVisit := func(filenode *fs.FilewalkNode) error {
-		if filenode.Err != nil {
-			return filenode.Err
-		}
-		hdr, file := fs.ScanFile(srcBasePath, filenode.Path, filenode.Info)
-		if file != nil {
-			defer file.Close()
-		}
-		fs.PlaceFile(destBasePath, hdr, file)
-		return nil
-	}
-	postVisit := func(filenode *fs.FilewalkNode) error {
-		if filenode.Info.IsDir() {
-			if err := fspatch.UtimesNano(filepath.Join(destBasePath, filenode.Path), fs.Epochwhen, filenode.Info.ModTime()); err != nil {
-				return err
+	fs.WithMtimeRepair(filepath.Dir(destBasePath), func() {
+		preVisit := func(filenode *fs.FilewalkNode) error {
+			if filenode.Err != nil {
+				return filenode.Err
 			}
+			hdr, file := fs.ScanFile(srcBasePath, filenode.Path, filenode.Info)
+			if file != nil {
+				defer file.Close()
+			}
+			fs.PlaceFile(destBasePath, hdr, file)
+			return nil
 		}
-		return nil
-	}
-	err = fs.Walk(srcBasePath, preVisit, postVisit)
-	meep.TryPlan{
-		{CatchAny: true, Handler: func(e error) {
-			panic(meep.Meep(
-				&rio.ErrAssembly{System: sys},
-				meep.Cause(err),
-			))
-		}},
-	}.MustHandle(err)
+		postVisit := func(filenode *fs.FilewalkNode) error {
+			if filenode.Info.IsDir() {
+				if err := fspatch.UtimesNano(filepath.Join(destBasePath, filenode.Path), fs.Epochwhen, filenode.Info.ModTime()); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		err = fs.Walk(srcBasePath, preVisit, postVisit)
+		meep.TryPlan{
+			{CatchAny: true, Handler: func(e error) {
+				panic(meep.Meep(
+					&rio.ErrAssembly{System: sys},
+					meep.Cause(err),
+				))
+			}},
+		}.MustHandle(err)
+	})
 
 	return copyEmplacement{path: destBasePath}
 }


### PR DESCRIPTION
 Support for (and test coverage for) using plain files in `rio/placer.Assembler`.

... meaning: the "file" transmat can be used in full formulas, as can bind mounts of individual files from the host.