### PR TITLE
Formula hash func

### DIFF
--- a/api/def/base58.go
+++ b/api/def/base58.go
@@ -1,0 +1,92 @@
+package def
+
+// The copy-paste history of this document is long:
+// Originally:
+//   Copyright (c) 2013-2014 Conformal Systems LLC.
+//   Use of this source code is governed by an ISC
+//   license that can be found in the LICENSE file
+//   at https://github.com/btcsuite/btcutil .
+// Modified by Juan Benet (juan@benet.ai),
+//   at https://github.com/jbenet/go-base58 .
+// Now here, modified by Eric Myhre; consider it
+//   either ISC, or Apachev2 at your convenience
+//   and legal ability to keep a straight face.
+
+// Changes from upstream: method renames, less exports,
+// fewer parameters.  This is only here as a necessity,
+// and generally used to create strings that are thereafter
+// considered opaque.
+
+import (
+	"math/big"
+	"strings"
+)
+
+// This alphabet is the modified base58 alphabet used by Bitcoin.
+// ("modified" compared to what?  I don't know.  There's not an RFC, afaict.)
+// It's also the defacto choice of IPFS systems.
+// It's also the order of the characters in ascii -- uppercase precedes lower.
+const b58alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+var bigRadix = big.NewInt(58)
+var bigZero = big.NewInt(0)
+
+func b58decode(b string) []byte {
+	answer := big.NewInt(0)
+	j := big.NewInt(1)
+
+	for i := len(b) - 1; i >= 0; i-- {
+		tmp := strings.IndexAny(b58alphabet, string(b[i]))
+		if tmp == -1 {
+			return []byte("")
+		}
+		idx := big.NewInt(int64(tmp))
+		tmp1 := big.NewInt(0)
+		tmp1.Mul(j, idx)
+
+		answer.Add(answer, tmp1)
+		j.Mul(j, bigRadix)
+	}
+
+	tmpval := answer.Bytes()
+
+	var numZeros int
+	for numZeros = 0; numZeros < len(b); numZeros++ {
+		if b[numZeros] != b58alphabet[0] {
+			break
+		}
+	}
+	flen := numZeros + len(tmpval)
+	val := make([]byte, flen, flen)
+	copy(val[numZeros:], tmpval)
+
+	return val
+}
+
+func b58encode(b []byte) string {
+	x := new(big.Int)
+	x.SetBytes(b)
+
+	answer := make([]byte, 0, len(b)*136/100)
+	for x.Cmp(bigZero) > 0 {
+		mod := new(big.Int)
+		x.DivMod(x, bigRadix, mod)
+		answer = append(answer, b58alphabet[mod.Int64()])
+	}
+
+	// leading zero bytes
+	for _, i := range b {
+		if i != 0 {
+			break
+		}
+		answer = append(answer, b58alphabet[0])
+	}
+
+	// reverse
+	alen := len(answer)
+	for i := 0; i < alen/2; i++ {
+		answer[i], answer[alen-1-i] = answer[alen-1-i], answer[i]
+	}
+
+	return string(answer)
+}

--- a/api/def/formula.go
+++ b/api/def/formula.go
@@ -16,9 +16,12 @@ type Formula struct {
 }
 
 /*
-	Hash the formula -- including the inputs, actions, and output slot specs;
-	excluding any actual output ware hashes, and excluding any non-conjecture-worthy
-	bits like warehouse coordinates from both the input and output sides.
+	Returns a hash covering parts of the formula such that the hash may be
+	expected to converge for formulae that describe identical setups.
+
+	Specifically, this hash includes the inputs, actions, and output slot specs;
+	it excludes any actual output ware hashes, and excludes any fields which
+	are incidental to correctly reproducing the task, such as warehouse URLs.
 
 	Caveat Emptor: this definition is should be treated as a proposal, not blessed.
 	Future versions may change the exact serialization used, and thus may not

--- a/api/def/formula.go
+++ b/api/def/formula.go
@@ -1,5 +1,12 @@
 package def
 
+import (
+	"crypto/sha512"
+	"encoding/base64"
+
+	"github.com/ugorji/go/codec"
+)
+
 /*
 	Formula describes `action(inputs) -> (outputs)`.
 */
@@ -7,4 +14,36 @@ type Formula struct {
 	Inputs  InputGroup  `json:"inputs"`
 	Action  Action      `json:"action"`
 	Outputs OutputGroup `json:"outputs"`
+}
+
+/*
+	Hash the formula -- including the inputs, actions, and output slot specs;
+	excluding any actual output ware hashes, and excluding any non-conjecture-worthy
+	bits like warehouse coordinates from both the input and output sides.
+
+	Caveat Emptor: this definition is should be treated as a proposal, not blessed.
+	Future versions may change the exact serialization used, and thus may not
+	map into the same strings as previous versions.
+
+	The returned string is the base58 encoding of a SHA-384 hash, though
+	there is no reason you should treat it as anything but opaque.
+	The returned string may be relied upon to be all alphanumeric characters.
+	FIXME actually use said encoding.
+*/
+func (f Formula) Hash() string {
+	// Copy and zero other things that we don't want to include in canonical IDs.
+	// This is working around lack of useful ways to pass encoding style hints down
+	//  with our current libraries.
+	f2 := f.Clone()
+	for _, spec := range f2.Inputs {
+		spec.Warehouses = nil
+	}
+	for _, spec := range f2.Outputs {
+		spec.Hash = ""
+		spec.Warehouses = nil
+	}
+	// Hash the rest, and thar we be.
+	hasher := sha512.New384()
+	codec.NewEncoder(hasher, &codec.CborHandle{}).MustEncode(f2)
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 }

--- a/api/def/formula.go
+++ b/api/def/formula.go
@@ -2,7 +2,6 @@ package def
 
 import (
 	"crypto/sha512"
-	"encoding/base64"
 
 	"github.com/ugorji/go/codec"
 )
@@ -45,5 +44,5 @@ func (f Formula) Hash() string {
 	// Hash the rest, and thar we be.
 	hasher := sha512.New384()
 	codec.NewEncoder(hasher, &codec.CborHandle{}).MustEncode(f2)
-	return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
+	return b58encode(hasher.Sum(nil))
 }

--- a/api/def/formula_hash_test.go
+++ b/api/def/formula_hash_test.go
@@ -1,0 +1,45 @@
+package def_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	rdef "go.polydawn.net/repeatr/api/def"
+)
+
+func TestFormulaHashFixtures(t *testing.T) {
+	Convey("Formulas should hash consistently", t, func() {
+		Convey("Given fixture 1", func() {
+			frm := &rdef.Formula{
+				Inputs: rdef.InputGroup{
+					"rootfs": &rdef.Input{
+						Type:       "tar",
+						Hash:       "aLMH4qK1EdlPDavdhErOs0BPxqO0i6lUaeRE4DuUmnNMxhHtF56gkoeSulvwWNqT",
+						Warehouses: rdef.WarehouseCoords{"http+ca://repeatr.s3.amazonaws.com/assets/"},
+						MountPath:  "/",
+					},
+				},
+				Action: rdef.Action{
+					Entrypoint: []string{"bash", "-c", "echo hello && sleep 5 && echo yes"},
+				},
+			}
+			Convey("It should match the fixture", func() {
+				So(frm.Hash(), ShouldEqual, "7dCwntFg7FtcUNs4FcRaUknXWWskG889kypU9y3BpWdVmT4aMA76zkZyjaNYL1x989")
+			})
+			Convey("Given a fixture that varies only in warehouses, it should match the same fixture", func() {
+				frm.Inputs["rootfs"].Warehouses = rdef.WarehouseCoords{"file+ca://./local/"}
+				So(frm.Hash(), ShouldEqual, "7dCwntFg7FtcUNs4FcRaUknXWWskG889kypU9y3BpWdVmT4aMA76zkZyjaNYL1x989")
+			})
+			Convey("Given changes in outputs, it should have a different fixture", func() {
+				frm.Outputs = rdef.OutputGroup{
+					"product": &rdef.Output{
+						Type:      "tar",
+						MountPath: "/output",
+					},
+				}
+				So(frm.Hash(), ShouldEqual, "8h8bRDwDAS39QtyQ7SNn9BYKZkXCxkxWMpCcHAMKdbvYe2qQ3r7TduVccHeCe8dk4y")
+			})
+		})
+	})
+}


### PR DESCRIPTION
(Finally!...) Add a `Hash()` function to `def.Formula`.

As the docs on the function describe: this function will return a string that may be expected to converge for formulae which describe identical setups.  Some elements of the structure that are *not* relevant to correctly reproducing the contained task (namely, data storage urls) are explicitly not included under the hash.

This has been a long time in coming: enabling this hash, and its semantics, have been a guiding factor in every part of Repeatr's design.  This hash [*] is effectively a content-addressable description of a computation to be performed, complete with environment.  This can be a primary key in a globally distributable database of *things that can be computed*; a single string usable as an index over arbitrary transformations of any data into any other data.  (Woo.)

<small>[*] or similarly behaving, if slightly different one, after some additional iterations of code</small>