### PR TITLE
fix def: Include conjectured output hashes in formula hash

### DIFF
--- a/api/def/formula.go
+++ b/api/def/formula.go
@@ -41,8 +41,10 @@ func (f Formula) Hash() string {
 		spec.Warehouses = nil
 	}
 	for _, spec := range f2.Outputs {
-		spec.Hash = ""
 		spec.Warehouses = nil
+		if !spec.Conjecture {
+			spec.Hash = ""
+		}
 	}
 	// Hash the rest, and thar we be.
 	hasher := sha512.New384()

--- a/api/def/formula_hash_test.go
+++ b/api/def/formula_hash_test.go
@@ -40,6 +40,28 @@ func TestFormulaHashFixtures(t *testing.T) {
 				}
 				So(frm.Hash(), ShouldEqual, "8h8bRDwDAS39QtyQ7SNn9BYKZkXCxkxWMpCcHAMKdbvYe2qQ3r7TduVccHeCe8dk4y")
 			})
+			Convey("Given non-conjectured outputs with hashes, it should match the same fixture", func() {
+				frm.Outputs = rdef.OutputGroup{
+					"product": &rdef.Output{
+						Type:       "tar",
+						MountPath:  "/output",
+						Conjecture: false,
+						Hash:       "baby's first hash",
+					},
+				}
+				So(frm.Hash(), ShouldEqual, "8h8bRDwDAS39QtyQ7SNn9BYKZkXCxkxWMpCcHAMKdbvYe2qQ3r7TduVccHeCe8dk4y")
+			})
+			Convey("Given conjectured outputs with hashes, it should have a different fixture", func() {
+				frm.Outputs = rdef.OutputGroup{
+					"product": &rdef.Output{
+						Type:       "tar",
+						MountPath:  "/output",
+						Conjecture: true,
+						Hash:       "baby's first hash",
+					},
+				}
+				So(frm.Hash(), ShouldEqual, "7rViXY4NfCiveRz3D5scyTJnJd9YegRgvwtiLFGXGyn6bzqM8H2wGxhmQw3bgvcnsp")
+			})
 		})
 	})
 }


### PR DESCRIPTION
The hashes of conjectured outputs should be consistent for the same set of
input hashes. It follows that because we include input hashes in the hash,
including output hashes for conjectured outputs should be safe.

This fixes #90

Signed-off-by: Vincent Ambo <tazjin@gmail.com>