### PR TITLE
Normalize work dir perms

### DIFF
--- a/core/executor/cradle/cradle.go
+++ b/core/executor/cradle/cradle.go
@@ -36,13 +36,17 @@ func MakeCradle(rootfsPath string, frm def.Formula) {
 func ensureWorkingDir(rootfsPath string, frm def.Formula) {
 	pth := filepath.Join(rootfsPath, frm.Action.Cwd)
 	uinfo := UserinfoForPolicy(frm.Action.Policy)
-	fs.MkdirAllWithAttribs(pth, fs.Metadata{
+	attribs := fs.Metadata{
+		Typeflag:   '5',
+		Name:       "./",
 		Mode:       0755,
 		ModTime:    fs.Epochwhen,
 		AccessTime: fs.Epochwhen,
 		Uid:        uinfo.Uid,
 		Gid:        uinfo.Gid,
-	})
+	}
+	fs.MkdirAllWithAttribs(pth, attribs)
+	fs.PlaceFile(pth, attribs, nil)
 }
 
 /*

--- a/core/executor/cradle/cradle.go
+++ b/core/executor/cradle/cradle.go
@@ -22,16 +22,14 @@ func MakeCradle(rootfsPath string, frm def.Formula) {
 }
 
 /*
-	Ensure that the working directory specified in the formula exists, and
-	if it had to be created, make it owned and writable by the user that
-	the contained process will be launched as.  (If it already existed, do
-	nothing; presumably you know what you're doing and intended whatever
-	content is already there and whatever permissions are already in effect.)
+	Ensure that the working directory specified in the formula exists,
+	ensure it has reasonable permissions, and ensure that it is
+	owned and writable by the user that the contained process will be
+	launched as.
+	(If the dir already exists, the permissions will be overwritten.)
 
-	TODO: review this policy of "if it exists, leave it".  This has super
-	confusing and frustrated results if you, say, have an input or mount
-	aimed at "/task/whatever".  Though that... could also be better addressed
-	by giving cradle more of a roll in filesystem assembly.
+	This is a basic sanity provision: many rootfs tarballs start with all
+	perms being 0:0, and most processes need *some* working directories.
 */
 func ensureWorkingDir(rootfsPath string, frm def.Formula) {
 	pth := filepath.Join(rootfsPath, frm.Action.Cwd)


### PR DESCRIPTION
Add normalization of the CWD perms to cradle's responsibilities.

The cradle package already does a bunch of work to make sure the container filesystem is a reasonable place to launch the user's process in.  It's desirable to keep this interference to a minimum, because every thing we add here implicitly becomes part of repeatr's contract and is a potential leakage through the otherwise absolute specificity of formulas.  In this case the reasons are still compelling: the path affected *is* specified by the formula; we are already interfering with that path; and this change set just refines the interference a bit.  (We should still probably have a flag to disable this interference entirely; not having that is a somewhat shameful omission, but adding it is a separate task.)

Previously, the cradle behavior was to mkdir the CWD if it doesn't exist in the container filesystem, but to leave it entirely alone if it did already exist.  Now, the behavior is to mkdir as necessary, but also always enforce that the owner and group IDs are set to the container UID and GID, and also to normalize the file permission mode.

This fixes some awkward user experience where an input path under the working dir path could cause the working dir to be created with root uid and gid... very irritating if your policy is the default, "routine", and thus has a different UID.  In that situation, the CWD will now always be writable (though files underneath created by the other input specification may still have other permissions), which should result in a much smoother experience in this fairly common case.
