### PR TITLE
rio: add ErrWareCorrupt to the returnable set.

### DIFF
--- a/rio/errors.go
+++ b/rio/errors.go
@@ -70,5 +70,6 @@ var TryPlanWhitelist = meep.TryPlan{
 	{ByType: &def.ErrWarehouseProblem{}, Handler: func(e error) { panic(e) }},
 	{ByType: &def.ErrWareDNE{}, Handler: func(e error) { panic(e) }},
 	{ByType: &def.ErrHashMismatch{}, Handler: func(e error) { panic(e) }},
+	{ByType: &def.ErrWareCorrupt{}, Handler: func(e error) { panic(e) }},
 	{CatchAny: true, Handler: meep.TryHandlerMapto(&ErrUnknown{})},
 }


### PR DESCRIPTION
The absence of this in the whitelist for valid errors for rio packages to return was an oversight.  The tar transmat already returns these in several places, and it is indeed a semantic and correct error to return.

Snipefix, noticed while reviewing https://github.com/polydawn/repeatr/pull/107 .