### PR TITLE
built-in Memoization support

### DIFF
--- a/cmd/repeatr/main.go
+++ b/cmd/repeatr/main.go
@@ -53,7 +53,7 @@ func Main(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io
 			EnumVar(&argsRun.Executor,
 				"runc", "chroot")
 		bhvs[cmdRun.FullCommand()] = behavior{&argsRun, func() error {
-			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr)
+			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr, "")
 		}}
 	}
 	{

--- a/cmd/repeatr/main.go
+++ b/cmd/repeatr/main.go
@@ -53,7 +53,7 @@ func Main(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io
 			EnumVar(&argsRun.Executor,
 				"runc", "chroot")
 		bhvs[cmdRun.FullCommand()] = behavior{&argsRun, func() error {
-			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr, "")
+			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr, nil)
 		}}
 	}
 	{

--- a/cmd/repeatr/main.go
+++ b/cmd/repeatr/main.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"go.polydawn.net/go-timeless-api/repeatr"
+	"go.polydawn.net/repeatr/config"
 )
 
 func main() {
@@ -53,7 +54,8 @@ func Main(ctx context.Context, args []string, stdin io.Reader, stdout, stderr io
 			EnumVar(&argsRun.Executor,
 				"runc", "chroot")
 		bhvs[cmdRun.FullCommand()] = behavior{&argsRun, func() error {
-			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr, nil)
+			memoDir := config.GetRepeatrMemoPath()
+			return Run(ctx, argsRun.Executor, argsRun.FormulaPath, stdout, stderr, memoDir)
 		}}
 	}
 	{

--- a/cmd/repeatr/memoization.go
+++ b/cmd/repeatr/memoization.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/polydawn/go-errcat"
+	"github.com/polydawn/refmt"
+	"github.com/polydawn/refmt/json"
+
+	"go.polydawn.net/go-timeless-api"
+	"go.polydawn.net/go-timeless-api/repeatr"
+)
+
+/*
+	Attempt to load a memoized runRecord.
+
+	If it doesn't exist (or memoDir is zero entirely), returns nil nil.
+*/
+func loadMemo(setupHash api.SetupHash, memoDir string) (rr *api.RunRecord, err error) {
+	// Nil result if no memodir.  That's fine.
+	if memoDir == "" {
+		return nil, nil
+	}
+
+	// Try to open file.
+	// REVIEW should probably use the threesplits too I guess?  unclear how far this needs to scale.
+	// REVIEW should we make sure this can jive with hitch runrecord layouts?  (which are not one-to-many with the setupHash?)
+	f, err := os.Open(filepath.Join(memoDir, string(setupHash)))
+	if err != nil {
+		// If not exists, no memo.  Fine.
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		// Any other error is worth warning the caller about.
+		return nil, Errorf(repeatr.ErrLocalCacheProblem, "error reading memodir: %s", err)
+	}
+	defer f.Close()
+
+	// Read and return the memoized runrecord.
+	if err := refmt.NewUnmarshallerAtlased(json.DecodeOptions{}, f, api.RepeatrAtlas).Unmarshal(rr); err != nil {
+		return nil, Errorf(repeatr.ErrLocalCacheProblem, "error parsing memo for setupHash %q: %s", setupHash, err)
+	}
+	return rr, nil
+}

--- a/cmd/repeatr/runCmd.go
+++ b/cmd/repeatr/runCmd.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"go.polydawn.net/go-timeless-api/repeatr"
+	"go.polydawn.net/rio/fs"
 )
 
 func Run(
@@ -14,7 +15,7 @@ func Run(
 	executorName string,
 	formulaPath string,
 	stdout, stderr io.Writer,
-	memoDir string,
+	memoDir *fs.AbsolutePath,
 ) (err error) {
 	// Load formula and build executor.
 	executor, err := demuxExecutor(executorName)
@@ -79,6 +80,12 @@ func Run(
 	// If a runrecord was returned always try to print it, even if we have
 	//  an error and thus it may be incomplete.
 	printRunRecord(stdout, stderr, rr)
+	// Memoization on the other hand only runs if there was no executor error.
+	if err == nil {
+		if err := saveMemo(formula.SetupHash(), memoDir, rr); err != nil {
+			fmt.Fprintf(stderr, "log: lvl=%s msg=%s err=%s\n", repeatr.LogWarn, "saving memoized runRecord failed", err)
+		}
+	}
 	// Return the executor error.
 	return err
 }

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"go.polydawn.net/rio/fs"
+)
+
+/*
+	Return the path to a dir that will be used to read memoization of
+	previous runs -- enabling short-circuit returns if they're encountered
+	again -- and also used as the place to record a memo of this run.
+
+	The default value is nil -- there will be no memoization --
+	and this can be set by the `REPEATR_MEMODIR` environment variable.
+*/
+func GetRepeatrMemoPath() *fs.AbsolutePath {
+	pth := os.Getenv("REPEATR_MEMODIR")
+	if pth == "" {
+		return nil
+	}
+	pth, err := filepath.Abs(pth)
+	if err != nil {
+		panic(err)
+	}
+	memoDir := fs.MustAbsolutePath(pth)
+	return &memoDir
+}


### PR DESCRIPTION
Memoization support!   Enable it by setting the `REPEATR_MEMODIR` env var.

You can see this in action by running the examples repeatedly, then doing it again with `REPEATR_MEMODIR=/tmp/memo ./example_runAll.sh` -- the second time you run with the memo dir set, you'll see very different outcomes.  The same runrecords will come out, but the user content (especially this is obvious from the one that invokes 'ls -la' for example) will be much less, because the real processes aren't re-run.

The default is not to memoize; you must opt in to it by setting the env var.  This is because full memoization may not be what a user expects by default when doing `repeatr run` in an interactive terminal, especially if the user is using a formula with the *intention* of generating side-effects (like the 'ls -la' example, again, say).

It's expected that most "planner" tools (see ecosystem diagram) that generate formulas and trigger swaths of repeatr-run invokations will almost certainly set the `REPEATR_MEMODIR` var... so, though we make it opt-in, we also expect that in the big picture users will rarely be bothered about it since there's another layer of tool that can make this disappear.